### PR TITLE
remove double header in sponsor page

### DIFF
--- a/src/templates/sponsor-page.js
+++ b/src/templates/sponsor-page.js
@@ -95,18 +95,12 @@ export const SponsorPageTemplate = class extends React.Component {
           />
           <SponsorHeader sponsor={sponsor} tier={tier} scanBadge={() => this.onBadgeScan()} />
           <section className={`section px-0 ${tier.sponsorPage.sponsorTemplate === 'big-header' ? 'pt-5' : 'pt-0'} pb-0`}>
-            <div className="mx-5 mt-0 mb-6">
-              {sponsor.title && <h1>{sponsor.title}</h1>}
-              {sponsor.intro && <span dangerouslySetInnerHTML={{ __html: parsedIntro }} />}
-            </div>
             <div className="columns mx-0 my-0">
               <div className="column is-three-quarters px-5 py-0">
-                {!sponsor.sideImage &&
-                  <div className={styles.sponsorIntro}>
-                    {sponsor.title && <h1>{sponsor.title}</h1>}
-                    {sponsor.intro && <span dangerouslySetInnerHTML={{ __html: parsedIntro }} />}
-                  </div>
-                }
+                <div className={styles.sponsorIntro}>
+                  {sponsor.title && <h1>{sponsor.title}</h1>}
+                  {sponsor.intro && <span dangerouslySetInnerHTML={{ __html: parsedIntro }} />}
+                </div>
                 {liveEvent &&
                   <LiveEventWidgetComponent
                     onEventClick={(ev) => this.onEventChange(ev)}


### PR DESCRIPTION
this bug was introduced when we removed the side Image for this page here: https://github.com/fntechgit/virtualevent-poc/commit/10bd64135e4b359a2d111f6c0176ac84b254e7ca