### PR TITLE
Adjusting sponsors align for carousel

### DIFF
--- a/src/components/SponsorComponent.js
+++ b/src/components/SponsorComponent.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {connect} from "react-redux";
+import { connect } from "react-redux";
 import Slider from "react-slick";
 import Link from '../components/Link'
 import { getSponsorURL } from '../utils/urlFormating'
@@ -13,7 +13,7 @@ const SponsorComponent = ({ page, sponsorsState, tiers, lobbyButton }) => {
       {sponsorsState.map((s, tierIndex) => {
         const sponsors = s.sponsors;
         const tier = tiers.find(t => t.id === s.tier[0].value);
-        if(!tier) return null;
+        if (!tier) return null;
         const template = page === 'lobby' ? tier.lobby.lobbyTemplate : page === 'event' ? tier.eventTemplate : 'expo-hall';
         if (sponsors?.length > 0) {
           renderButton = true;
@@ -122,23 +122,23 @@ const SponsorComponent = ({ page, sponsorsState, tiers, lobbyButton }) => {
                           </Link>
                         </div>
                         : sponsor.usesSponsorPage ?
-                        <div className={`
+                          <div className={`
                           ${styles.imageBox} 
                           ${tier.expoHallPage?.expoHallTemplate === 'big-images' ? styles.large : tier.expoHallPage?.expoHallTemplate === 'medium-images' ? styles.medium : styles.small}`}
-                          key={`${s.tier.label}-${index}`}
-                        >
-                          <Link to={`/a/sponsor/${getSponsorURL(sponsor.id, sponsor.name)}`}>
+                            key={`${s.tier.label}-${index}`}
+                          >
+                            <Link to={`/a/sponsor/${getSponsorURL(sponsor.id, sponsor.name)}`}>
+                              <img src={sponsor.logo} alt={sponsor.name} />
+                            </Link>
+                          </div>
+                          :
+                          <div className={`
+                          ${styles.imageBox} 
+                          ${tier.expoHallPage?.expoHallTemplate === 'big-images' ? styles.large : tier.expoHallPage?.expoHallTemplate === 'medium-images' ? styles.medium : styles.small}`}
+                            key={`${s.tier.label}-${index}`}
+                          >
                             <img src={sponsor.logo} alt={sponsor.name} />
-                          </Link>
-                        </div>
-                        :
-                        <div className={`
-                          ${styles.imageBox} 
-                          ${tier.expoHallPage?.expoHallTemplate === 'big-images' ? styles.large : tier.expoHallPage?.expoHallTemplate === 'medium-images' ? styles.medium : styles.small}`}
-                          key={`${s.tier.label}-${index}`}
-                        >
-                          <img src={sponsor.logo} alt={sponsor.name} />
-                        </div>
+                          </div>
                     )
                   })}
                 </div>
@@ -175,7 +175,9 @@ const SponsorComponent = ({ page, sponsorsState, tiers, lobbyButton }) => {
                                 <img src={sponsor.advertiseImage ? sponsor.advertiseImage : sponsor.logo} alt={sponsor.name} />
                               </Link>
                               :
-                              <img src={sponsor.advertiseImage ? sponsor.advertiseImage : sponsor.logo} alt={sponsor.name} />
+                              <Link>
+                                <img src={sponsor.advertiseImage ? sponsor.advertiseImage : sponsor.logo} alt={sponsor.name} />
+                              </Link>
                         )
                       })}
                     </Slider>

--- a/src/styles/sponsor.module.scss
+++ b/src/styles/sponsor.module.scss
@@ -2,6 +2,9 @@
 
 .first-container {
   margin-top: 0px !important;
+  &.carousel-container {
+    padding-top: 1px;
+  }
 }
 
 .big-image-container {
@@ -135,9 +138,10 @@
     width: 100%;
     text-align: center;
   }
-
-  img {
-    margin: 1rem auto;
+  &:not(:first-of-type) {
+    img {
+      margin: 1rem auto;
+    }
   }
 }
 


### PR DESCRIPTION


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

* Removes the margin on the images of the first sponsor slider to make it align with the other columns
* Wraps single images into link component without href to keep the consistency of the align for all the images (single images were affected by slider library styles and they looked misaligned)

eg. 
![image](https://user-images.githubusercontent.com/19543853/137409011-2c3b1453-baae-46b1-a175-6595c24403aa.png)


**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

None

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2668076

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
