### PR TITLE
Removes margin top to live event widget container.

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -303,7 +303,7 @@ h2 {
 }
 
 .live-event-container {
-  margin: 15px 0;
+  margin: 0 0 15px;
 }
 
 .disqus-container {


### PR DESCRIPTION
Reverts margin top change introduced in #183