### PR TITLE
Uses gatsby navigate instead of reach router's navigate.

### DIFF
--- a/src/routes/authorization-callback-route.js
+++ b/src/routes/authorization-callback-route.js
@@ -13,7 +13,8 @@
 
 import React from 'react'
 import URI from "urijs"
-import { Redirect, navigate } from '@reach/router'
+import { navigate } from "gatsby"
+import { Redirect } from '@reach/router'
 import { connect } from 'react-redux';
 import { AbstractAuthorizationCallbackRoute } from "openstack-uicore-foundation/lib/components";
 import { getUserProfile } from '../actions/user-actions'


### PR DESCRIPTION
To fix navigation issue after idp callback.