### PR TITLE
Disable reg-lite for invite only events

### DIFF
--- a/src/components/MarketingHeroComponent.js
+++ b/src/components/MarketingHeroComponent.js
@@ -13,7 +13,7 @@ import RegistrationLiteComponent from "./RegistrationLiteComponent";
 
 import styles from "../styles/lobby-hero.module.scss";
 
-const MarketingHeroComponent = ({ siteSettings, summit_phase, isLoggedUser, location }) => {
+const MarketingHeroComponent = ({ siteSettings, summit_phase, isLoggedUser, summit, location }) => {
 
   const sliderRef = useRef(null);
   const [sliderHeight, setSliderHeight] = useState(424);
@@ -70,7 +70,7 @@ const MarketingHeroComponent = ({ siteSettings, summit_phase, isLoggedUser, loca
 
     return (
       <>
-        {registerButton.display &&
+        {registerButton.display && !summit.invite_only_registration &&
           (
             <span className={styles.link}>
               <RegistrationLiteComponent location={location} />
@@ -160,8 +160,9 @@ const MarketingHeroComponent = ({ siteSettings, summit_phase, isLoggedUser, loca
   );
 }
 
-const mapStateToProps = ({ clockState, settingState, userState }) => ({
+const mapStateToProps = ({ clockState, settingState, userState, summitState }) => ({
   summit_phase: clockState.summit_phase,
+  summit: summitState.summit,
   siteSettings: settingState.siteSettings,
   userProfile: userState.userProfile
 });

--- a/src/components/RegistrationLiteComponent.js
+++ b/src/components/RegistrationLiteComponent.js
@@ -139,7 +139,7 @@ const RegistrationLiteComponent = ({
                 </button>
             }
             <div>
-                {isActive && <RegistrationLiteWidget {...widgetProps} />}
+                {isActive && !summit.invite_only_registration && <RegistrationLiteWidget {...widgetProps} />}
             </div>
         </>
     )


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Disable the reg-lite widget for summits that are invite only

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

* Summits that are invite-only would not load the reg-lite widget

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2780784

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>