### PR TITLE
Hotfix/poster show detail ux

### DIFF
--- a/src/components/poster-card/index.jsx
+++ b/src/components/poster-card/index.jsx
@@ -42,7 +42,7 @@ const PosterCard = ({ poster, showDetail, canVote, isVoted, toggleVote, showDeta
       >
         <div className={`${styles.overlay} ${hover ? styles.overlay__hover : ''}`}
           onMouseEnter={() => setHover(true)} 
-          onMouseLeave={() => setHover(false)}
+          onMouseOut={() => setHover(false)}
           onContextMenu={(e) => e.preventDefault()}
           onClick={handleClick}
         >

--- a/src/components/poster-card/index.jsx
+++ b/src/components/poster-card/index.jsx
@@ -40,27 +40,27 @@ const PosterCard = ({ poster, showDetail, canVote, isVoted, toggleVote, showDeta
         src={posterImage.public_url}
         className={styles.header}
       >
-        <div className={`${styles.overlay} ${showDetail && hover ? styles.overlay__hover : ''}`} 
+        <div className={`${styles.overlay} ${hover ? styles.overlay__hover : ''}`}
           onMouseEnter={() => setHover(true)} 
           onMouseLeave={() => setHover(false)}
           onContextMenu={(e) => e.preventDefault()}
           onClick={handleClick}
         >
-          { showDetail && hover &&
+          { hover &&
           <button className={`${styles.button} button is-large`}>
             <i className={'fa fa-2x fa-eye icon is-large'} />
             <b>Detail</b>
           </button>
           }
           <ControlledZoom
-                isZoomed={isZoomed}
-                onZoomChange={handleZoomChange}
-                zoomMargin={50}
-                overlayBgColorStart="rgba(0, 0, 0, 0)"
-                overlayBgColorEnd="rgba(0, 0, 0, 0.8)"
-            >
-                <PosterImage mediaUpload={posterImage} shouldShow={isZoomed}/>
-            </ControlledZoom>
+            isZoomed={isZoomed}
+            onZoomChange={handleZoomChange}
+            zoomMargin={50}
+            overlayBgColorStart="rgba(0, 0, 0, 0)"
+            overlayBgColorEnd="rgba(0, 0, 0, 0.8)"
+          >
+            <PosterImage mediaUpload={posterImage} shouldShow={isZoomed}/>
+          </ControlledZoom>
         </div>
       </BlockImage>
       <div className={styles.body}>
@@ -83,7 +83,6 @@ const PosterCard = ({ poster, showDetail, canVote, isVoted, toggleVote, showDeta
 
 PosterCard.propTypes = {
   poster: PropTypes.object.isRequired,
-  showDetail: PropTypes.bool,
   canVote: PropTypes.bool.isRequired,
   isVoted: PropTypes.bool.isRequired,
   toggleVote: PropTypes.func.isRequired

--- a/src/components/poster-card/index.module.scss
+++ b/src/components/poster-card/index.module.scss
@@ -12,7 +12,6 @@
     box-shadow: 0 0 0 1px rgba(216, 216, 216, 1);
     background-blend-mode: darken;
     transition: 0.3s;
-    pointer-events: none;
     .overlay {
       z-index: 100;
       width: 100%;
@@ -27,6 +26,7 @@
       }
     }
     .button {
+      pointer-events: none;
       position: absolute;
       height: 4rem;
       width: 17rem;

--- a/src/components/poster-grid/index.jsx
+++ b/src/components/poster-grid/index.jsx
@@ -5,13 +5,12 @@ import PosterCard from '../poster-card';
 
 import styles from './index.module.scss';
 
-const PosterGrid = ({ posters, canVote, toggleVote, votes, showDetail = null, showDetailPage = null }) => {
+const PosterGrid = ({ posters, canVote, toggleVote, votes, showDetailPage = null }) => {
   if (!posters) return null;
   const cards = posters.map(poster => 
     <PosterCard
       key={`poster-${poster.id}`}
       poster={poster}
-      showDetail={showDetail}
       showDetailPage={showDetailPage ? () => showDetailPage(poster.id) : null}
       canVote={canVote}
       isVoted={!!votes.find(v => v.presentation_id === poster.id)}
@@ -26,7 +25,6 @@ const PosterGrid = ({ posters, canVote, toggleVote, votes, showDetail = null, sh
 };
 PosterGrid.propTypes = {
   posters: PropTypes.array.isRequired,
-  showDetail: PropTypes.bool,
   showDetailPage: PropTypes.func,
   canVote: PropTypes.bool.isRequired,
   toggleVote: PropTypes.func.isRequired,


### PR DESCRIPTION
- Removes showDetail prop callback from poster components, since showDetail is being implemented within poster card component (for the time being).
- Fixes poster card hover detection.