### PR TITLE
Feature/posters can vote

### DIFF
--- a/src/actions/clock-actions.js
+++ b/src/actions/clock-actions.js
@@ -2,7 +2,7 @@ import { createAction } from 'openstack-uicore-foundation/lib/methods';
 
 import { PHASES, getSummitPhase, getEventPhase } from '../utils/phasesUtils';
 
-import { updateVotingPeriodsPhases } from '../actions/presentation-actions';
+import { updateVotingPeriodsPhase } from '../actions/presentation-actions';
 
 export const SUMMIT_PHASE_AFTER = 'SUMMIT_PHASE_AFTER';
 export const SUMMIT_PHASE_DURING = 'SUMMIT_PHASE_DURING';
@@ -18,7 +18,7 @@ export const updateClock = (timestamp) => (dispatch) => {
   dispatch(createAction(UPDATE_CLOCK)({ timestamp }));
   dispatch(updateSummitPhase());
   dispatch(updateEventsPhase());
-  dispatch(updateVotingPeriodsPhases());
+  dispatch(updateVotingPeriodsPhase());
 };
 
 export const updateSummitPhase = () => (dispatch, getState) => {

--- a/src/actions/clock-actions.js
+++ b/src/actions/clock-actions.js
@@ -2,6 +2,8 @@ import { createAction } from 'openstack-uicore-foundation/lib/methods';
 
 import { PHASES, getSummitPhase, getEventPhase } from '../utils/phasesUtils';
 
+import { updateVotingPeriodsPhases } from '../actions/presentation-actions';
+
 export const SUMMIT_PHASE_AFTER = 'SUMMIT_PHASE_AFTER';
 export const SUMMIT_PHASE_DURING = 'SUMMIT_PHASE_DURING';
 export const SUMMIT_PHASE_BEFORE = 'SUMMIT_PHASE_BEFORE';
@@ -16,6 +18,7 @@ export const updateClock = (timestamp) => (dispatch) => {
   dispatch(createAction(UPDATE_CLOCK)({ timestamp }));
   dispatch(updateSummitPhase());
   dispatch(updateEventsPhase());
+  dispatch(updateVotingPeriodsPhases());
 };
 
 export const updateSummitPhase = () => (dispatch, getState) => {

--- a/src/actions/presentation-actions.js
+++ b/src/actions/presentation-actions.js
@@ -8,9 +8,9 @@ import {
 
 import { customErrorHandler } from '../utils/customErrorHandler';
 
-import { getEnvVariable, SUMMIT_API_BASE_URL, SUMMIT_ID } from '../utils/envVariables';
+import { getVotingPeriodPhase } from '../utils/phasesUtils';
 
-import { SET_USER_ORDER } from "./user-actions";
+import { getEnvVariable, SUMMIT_API_BASE_URL, SUMMIT_ID } from '../utils/envVariables';
 
 export const SET_INITIAL_DATASET = 'VOTEABLE_PRESENTATIONS_SET_INITIAL_DATASET';
 export const GET_VOTEABLE_PRESENTATIONS = 'GET_VOTEABLE_PRESENTATIONS';
@@ -20,7 +20,8 @@ export const VOTEABLE_PRESENTATIONS_UPDATE_FILTER = 'VOTEABLE_PRESENTATIONS_UPDA
 export const GET_PRESENTATION_DETAILS = 'GET_PRESENTATION_DETAILS';
 export const GET_PRESENTATION_DETAILS_ERROR = 'GET_PRESENTATION_DETAILS_ERROR';
 export const GET_RECOMMENDED_PRESENTATIONS = 'GET_RECOMMENDED_PRESENTATIONS';
-
+export const VOTING_PERIOD_ADD = 'VOTING_PERIOD_ADD';
+export const VOTING_PERIOD_PHASE_CHANGE = 'VOTING_PERIOD_PHASE_CHANGE';
 
 export const setInitialDataSet = () => (dispatch, getState) => Promise.resolve().then(() => {
   const { userState: { userProfile } } = getState();
@@ -167,4 +168,40 @@ export const getRecommendedPresentations = (trackGroups) => async (dispatch, get
       dispatch(stopLoading());
       return (e);
   });
-}; 
+};
+
+export const updateVotingPeriodsPhases = () => (dispatch, getState) => {
+
+  const {
+          summitState: { summit: { track_groups: trackGroups } },
+          presentationsState: { votingPeriods: votingPeriodsByClassName },
+          clockState: { nowUtc }
+        } = getState();
+
+  if (Object.keys(votingPeriodsByClassName).length === 0) {
+    trackGroups.forEach(trackGroup => {
+      const { max_attendee_votes: maxAttendeeVotes } = trackGroup;
+      let { begin_attendee_voting_period_date: startDate, end_attendee_voting_period_date: endDate } = trackGroup;
+      if (startDate <= 0) startDate = null;
+      if (endDate <= 0) endDate = null;
+      const votingPeriod = {
+        startDate,
+        endDate,
+        maxAttendeeVotes,
+        phase: null
+      };
+      dispatch(createAction(VOTING_PERIOD_ADD)({ entity: trackGroup, votingPeriod }));
+    });
+  }
+
+  Object.entries(votingPeriodsByClassName).forEach(entry => {
+    const [className, votingPeriods] = entry;
+    Object.entries(votingPeriods).forEach(entry => {
+      const [entityId, votingPeriod] = entry;
+      const newPhase = getVotingPeriodPhase(votingPeriod, nowUtc);
+      if (votingPeriod.phase !== newPhase) {
+        dispatch(createAction(VOTING_PERIOD_PHASE_CHANGE)({ className, entityId, phase: newPhase }));
+      }
+    });
+  });
+};

--- a/src/actions/user-actions.js
+++ b/src/actions/user-actions.js
@@ -38,7 +38,9 @@ export const ADD_TO_SCHEDULE                   = 'ADD_TO_SCHEDULE';
 export const REMOVE_FROM_SCHEDULE              = 'REMOVE_FROM_SCHEDULE';
 export const SCHEDULE_SYNC_LINK_RECEIVED       = 'SCHEDULE_SYNC_LINK_RECEIVED';
 export const SET_USER_ORDER                    = 'SET_USER_ORDER';
+export const CAST_PRESENTATION_VOTE_REQUEST   = 'CAST_PRESENTATION_VOTE_REQUEST';
 export const CAST_PRESENTATION_VOTE_RESPONSE   = 'CAST_PRESENTATION_VOTE_RESPONSE';
+export const UNCAST_PRESENTATION_VOTE_REQUEST = 'UNCAST_PRESENTATION_VOTE_REQUEST';
 export const UNCAST_PRESENTATION_VOTE_RESPONSE = 'UNCAST_PRESENTATION_VOTE_RESPONSE';
 export const TOGGLE_PRESENTATION_VOTE          = 'TOGGLE_PRESENTATION_VOTE';
 
@@ -235,7 +237,7 @@ export const castPresentationVote = (presentation) => async (dispatch, getState)
         // first 'confirm' as local vote
         dispatch(createAction(TOGGLE_PRESENTATION_VOTE)({ presentation, isVoted: true }));
         // inmediately remove vote
-        dispatch(createAction(TOGGLE_PRESENTATION_VOTE)({ presentation, isVoted: false }));
+        dispatch(createAction(TOGGLE_PRESENTATION_VOTE)({ presentation, isVoted: false, reverting: true }));
       }
     } else {
       console.log('castPresentationVote error code: ', status, text);
@@ -243,11 +245,12 @@ export const castPresentationVote = (presentation) => async (dispatch, getState)
   };
 
   return postRequest(
-    null,
+    createAction(CAST_PRESENTATION_VOTE_REQUEST),
     createAction(CAST_PRESENTATION_VOTE_RESPONSE),
     `${getEnvVariable('SUMMIT_API_BASE_URL')}/api/v1/summits/${getEnvVariable(SUMMIT_ID)}/presentations/${presentation.id}/attendee-votes`,
     {},
-    errorHandler
+    errorHandler,
+    { presentation }
   )(params)(dispatch).catch(errorHandler);
 };
 
@@ -273,11 +276,12 @@ export const uncastPresentationVote = (presentation) => async (dispatch, getStat
   };
 
   return deleteRequest(
-    null,
+    createAction(UNCAST_PRESENTATION_VOTE_REQUEST),
     createAction(UNCAST_PRESENTATION_VOTE_RESPONSE)({ presentation }),
     `${getEnvVariable('SUMMIT_API_BASE_URL')}/api/v1/summits/${getEnvVariable(SUMMIT_ID)}/presentations/${presentation.id}/attendee-votes`,
     {},
-    errorHandler
+    errorHandler,
+    { presentation }
   )(params)(dispatch).catch(errorHandler);
 };
 

--- a/src/actions/user-actions.js
+++ b/src/actions/user-actions.js
@@ -226,12 +226,17 @@ export const castPresentationVote = (presentation) => async (dispatch, getState)
 
   const errorHandler = (err) => (dispatch, state) => {
     const { status, response: { text } } = err;
-    if (status === 412 && text.includes('Max. allowed votes')) {
-      // need to revert button state
-      // first 'confirms' vote
-      dispatch(createAction(TOGGLE_PRESENTATION_VOTE)({ presentation, isVoted: true }));
-      // inmediately removes vote
-      dispatch(createAction(TOGGLE_PRESENTATION_VOTE)({ presentation, isVoted: false }));
+    if (status === 412) {
+      if (text.includes('already vote')) {
+        // 'confirm' as local vote
+        dispatch(createAction(TOGGLE_PRESENTATION_VOTE)({ presentation, isVoted: true }));
+      } else if (text.includes('Max. allowed votes')) {
+        // need to revert button state
+        // first 'confirm' as local vote
+        dispatch(createAction(TOGGLE_PRESENTATION_VOTE)({ presentation, isVoted: true }));
+        // inmediately remove vote
+        dispatch(createAction(TOGGLE_PRESENTATION_VOTE)({ presentation, isVoted: false }));
+      }
     } else {
       console.log('castPresentationVote error code: ', status, text);
     }

--- a/src/components/poster-card/index.jsx
+++ b/src/components/poster-card/index.jsx
@@ -11,7 +11,7 @@ import placeholder from '../../img/poster_fallback.png';
 
 import 'react-medium-image-zoom/dist/styles.css'
 
-const PosterCard = ({ poster, showDetail, canVote, isVoted, toggleVote, showDetailPage }) => {
+const PosterCard = ({ poster, showDetail, showVoteButton, canVote, isVoted, toggleVote, showDetailPage }) => {
   const [hover, setHover] = useState(false);
   const [isZoomed, setIsZoomed] = useState(false)
   const handleZoomChange = useCallback(shouldZoom => {
@@ -71,11 +71,13 @@ const PosterCard = ({ poster, showDetail, canVote, isVoted, toggleVote, showDeta
         { track?.name && track?.color &&
         <span className={styles.track} style={{backgroundColor: track.color}}>{track.name}</span>
         }
+        { showVoteButton &&
         <VoteButton
           isVoted={isVoted}
           canVote={canVote}
           toggleVote={() => toggleVote(poster, !isVoted)}
         />
+        }
       </div>
     </article>
   );
@@ -83,6 +85,7 @@ const PosterCard = ({ poster, showDetail, canVote, isVoted, toggleVote, showDeta
 
 PosterCard.propTypes = {
   poster: PropTypes.object.isRequired,
+  showVoteButton: PropTypes.bool.isRequired,
   canVote: PropTypes.bool.isRequired,
   isVoted: PropTypes.bool.isRequired,
   toggleVote: PropTypes.func.isRequired

--- a/src/components/poster-card/vote-button.js
+++ b/src/components/poster-card/vote-button.js
@@ -5,49 +5,50 @@ import styles from './vote-button.module.scss';
 
 const VoteButton = ({ isVoted, canVote, toggleVote, style }) => {
   const [togglingVote, setTogglingVote] = useState(false);
+  const [vote, setVote] = useState(isVoted);
   const [iconClass, setIconClass] = useState(isVoted ? 'fa-heart' : 'fa-heart-o');
   const [buttonClass, setButtonClass] = useState(isVoted ? styles.added : styles.add);
   const [title, setTitle] = useState(isVoted ? 'Remove vote' : canVote ? 'Vote for this poster!' : 'Maximun votes registered');
-  const [disabled, setDisabled] = useState(!(canVote || isVoted));
 
   const handleClick = ev => {
     ev.preventDefault();
     ev.stopPropagation();
     if (toggleVote) {
       toggleVote();
-      setTogglingVote(true);
+      setVote(!vote);
     }
   };
 
-  const configureButton = (isVoted, togglingVote) => {
-    setIconClass(isVoted === togglingVote ? 'fa-heart-o' : 'fa-heart');
-    if (isVoted) {
-      setButtonClass(togglingVote ? styles.add : styles.added);
-      setTitle(togglingVote ? 'Removing vote' : 'Remove vote');
+  const configureButton = () => {
+    if (vote !== isVoted) {
+      setTitle(vote ? 'Voting!' : 'Removing vote');
+      setIconClass(vote ? 'fa-heart' : 'fa-heart-o');
+      setButtonClass(vote ? styles.added : styles.add);
     } else {
-      setButtonClass(togglingVote ? styles.added : canVote ? styles.add : styles.disabled);
-      setTitle(togglingVote ? 'Voting!' : canVote ? 'Vote for this poster!' : 'Maximun votes registered');
+      setTitle(vote ? 'Remove vote' : canVote ? 'Vote for this poster!' : 'Maximun votes registered');
+      setIconClass(vote ? 'fa-heart' : 'fa-heart-o');
+      setButtonClass(vote ? styles.added : canVote ? styles.add : styles.disabled);
     }
   };
 
   useEffect(() => {
-    if (togglingVote) {
-      setTogglingVote(false);
-    } else {
-      configureButton(isVoted, togglingVote);
+    configureButton();
+  }, [vote, canVote]);
+
+  useEffect(() => {
+    if (isVoted !== vote) {
+      setVote(isVoted);
+    } else if (canVote) {
+      configureButton();
     }
   }, [isVoted]);
-
-  useEffect(() => {
-    configureButton(isVoted, togglingVote);
-  }, [togglingVote]);
 
   return (
     <button
       title={title}
       className={`${styles.voteButton} ${buttonClass}`}
       onClick={handleClick}
-      disabled={disabled || togglingVote}
+      disabled={!(canVote || isVoted) || (vote !== isVoted)}
       style={style}
     >
       <i className={`fa ${iconClass}`} aria-hidden="true" />

--- a/src/components/poster-card/vote-button.js
+++ b/src/components/poster-card/vote-button.js
@@ -38,7 +38,7 @@ const VoteButton = ({ isVoted, canVote, toggleVote, style }) => {
   useEffect(() => {
     if (isVoted !== vote) {
       setVote(isVoted);
-    } else if (canVote) {
+    } else {
       configureButton();
     }
   }, [isVoted]);

--- a/src/components/poster-grid/index.jsx
+++ b/src/components/poster-grid/index.jsx
@@ -13,13 +13,13 @@ import { PHASES } from '../../utils/phasesUtils';
 
 import styles from './index.module.scss';
 
-const PosterGrid = ({ posters, showDetailPage = null, votingAllowed, votingPeriods, votes, toggleVote }) => {
+const PosterGrid = ({ allPosters, posters, showDetailPage = null, votingAllowed, votingPeriods, votes, toggleVote }) => {
   const [votesPerTrackGroup, setVotesPerTrackGroup] = useState({});
   const [remainingVotes, setRemainingVotes] = useState({});
 
   useEffect(() => {
-    setVotesPerTrackGroup(calculateVotesPerTrackGroup(posters, votes));
-  }, [posters, votes]);
+    setVotesPerTrackGroup(calculateVotesPerTrackGroup(allPosters, votes));
+  }, [allPosters, votes]);
 
   useEffect(() => {
     if (TRACK_GROUP_CLASS_NAME in votingPeriods)
@@ -61,6 +61,7 @@ const PosterGrid = ({ posters, showDetailPage = null, votingAllowed, votingPerio
 };
 
 PosterGrid.propTypes = {
+  allPosters: PropTypes.array.isRequired,
   posters: PropTypes.array.isRequired,
   showDetailPage: PropTypes.func,
   votingAllowed: PropTypes.bool.isRequired,

--- a/src/components/poster-grid/index.jsx
+++ b/src/components/poster-grid/index.jsx
@@ -1,18 +1,54 @@
-import React from 'react';
-
+import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
+
 import PosterCard from '../poster-card';
+
+import {
+  calculateRemaingVotes,
+  calculateVotesPerTrackGroup,
+  TRACK_GROUP_CLASS_NAME
+} from '../../utils/voting-utils';
+
+import { PHASES } from '../../utils/phasesUtils';
 
 import styles from './index.module.scss';
 
-const PosterGrid = ({ posters, canVote, toggleVote, votes, showDetailPage = null }) => {
+const PosterGrid = ({ posters, showDetailPage = null, votingAllowed, votingPeriods, votes, toggleVote }) => {
+  const [votesPerTrackGroup, setVotesPerTrackGroup] = useState({});
+  const [remainingVotes, setRemainingVotes] = useState({});
+
+  useEffect(() => {
+    setVotesPerTrackGroup(calculateVotesPerTrackGroup(posters, votes));
+  }, [posters, votes]);
+
+  useEffect(() => {
+    if (TRACK_GROUP_CLASS_NAME in votingPeriods)
+      setRemainingVotes(calculateRemaingVotes(votingPeriods[TRACK_GROUP_CLASS_NAME], votesPerTrackGroup));
+  }, [votingPeriods, votesPerTrackGroup]);
+
+  const canVote = useCallback((poster) => {
+    let result = false;
+    if (!(TRACK_GROUP_CLASS_NAME in votingPeriods)) return result;
+    if (poster && poster.track && poster.track.track_groups) {
+      poster.track.track_groups.forEach(trackGroupId => {
+        if (trackGroupId in votingPeriods[TRACK_GROUP_CLASS_NAME]) {
+          const votingPeriod = votingPeriods[TRACK_GROUP_CLASS_NAME][trackGroupId];
+          result = votingPeriod.phase === PHASES.DURING && remainingVotes[trackGroupId] > 0;
+        }
+      });
+    }
+    return result;
+  }, [remainingVotes]);
+
   if (!posters) return null;
+
   const cards = posters.map(poster => 
     <PosterCard
       key={`poster-${poster.id}`}
       poster={poster}
       showDetailPage={showDetailPage ? () => showDetailPage(poster.id) : null}
-      canVote={canVote}
+      showVoteButton={votingAllowed}
+      canVote={canVote(poster)}
       isVoted={!!votes.find(v => v.presentation_id === poster.id)}
       toggleVote={toggleVote}
     />
@@ -23,11 +59,14 @@ const PosterGrid = ({ posters, canVote, toggleVote, votes, showDetailPage = null
     </div>
   )
 };
+
 PosterGrid.propTypes = {
   posters: PropTypes.array.isRequired,
   showDetailPage: PropTypes.func,
-  canVote: PropTypes.bool.isRequired,
-  toggleVote: PropTypes.func.isRequired,
-  votes: PropTypes.array.isRequired
+  votingAllowed: PropTypes.bool.isRequired,
+  votingPeriods: PropTypes.object.isRequired,
+  votes: PropTypes.array.isRequired,
+  toggleVote: PropTypes.func.isRequired
 };
+
 export default PosterGrid;

--- a/src/components/poster-grid/index.jsx
+++ b/src/components/poster-grid/index.jsx
@@ -3,42 +3,25 @@ import PropTypes from 'prop-types';
 
 import PosterCard from '../poster-card';
 
-import {
-  calculateRemaingVotes,
-  calculateVotesPerTrackGroup,
-  TRACK_GROUP_CLASS_NAME
-} from '../../utils/voting-utils';
-
 import { PHASES } from '../../utils/phasesUtils';
 
 import styles from './index.module.scss';
 
-const PosterGrid = ({ allPosters, posters, showDetailPage = null, votingAllowed, votingPeriods, votes, toggleVote }) => {
-  const [votesPerTrackGroup, setVotesPerTrackGroup] = useState({});
-  const [remainingVotes, setRemainingVotes] = useState({});
+const PosterGrid = ({ posters, showDetailPage = null, votingAllowed, votingPeriods, votes, toggleVote }) => {
 
-  useEffect(() => {
-    setVotesPerTrackGroup(calculateVotesPerTrackGroup(allPosters, votes));
-  }, [allPosters, votes]);
-
-  useEffect(() => {
-    if (TRACK_GROUP_CLASS_NAME in votingPeriods)
-      setRemainingVotes(calculateRemaingVotes(votingPeriods[TRACK_GROUP_CLASS_NAME], votesPerTrackGroup));
-  }, [votingPeriods, votesPerTrackGroup]);
+  const isDuringVotingPhase = useCallback((poster) => {
+    const results = poster.track?.track_groups?.map(trackGroupId =>
+      votingPeriods[trackGroupId]?.phase === PHASES.DURING
+    );
+    return results && results.length ? results.every(r => !!r) : false;
+  }, [votingPeriods]);
 
   const canVote = useCallback((poster) => {
-    let result = false;
-    if (!(TRACK_GROUP_CLASS_NAME in votingPeriods)) return result;
-    if (poster && poster.track && poster.track.track_groups) {
-      poster.track.track_groups.forEach(trackGroupId => {
-        if (trackGroupId in votingPeriods[TRACK_GROUP_CLASS_NAME]) {
-          const votingPeriod = votingPeriods[TRACK_GROUP_CLASS_NAME][trackGroupId];
-          result = votingPeriod.phase === PHASES.DURING && remainingVotes[trackGroupId] > 0;
-        }
-      });
-    }
-    return result;
-  }, [remainingVotes]);
+    const results = poster.track?.track_groups?.map(trackGroupId =>
+      votingPeriods[trackGroupId]?.remainingVotes > 0
+    );
+    return results && results.length ? results.every(r => !!r) : false;
+  }, [votingPeriods]);
 
   if (!posters) return null;
 
@@ -47,7 +30,7 @@ const PosterGrid = ({ allPosters, posters, showDetailPage = null, votingAllowed,
       key={`poster-${poster.id}`}
       poster={poster}
       showDetailPage={showDetailPage ? () => showDetailPage(poster.id) : null}
-      showVoteButton={votingAllowed}
+      showVoteButton={votingAllowed && isDuringVotingPhase(poster)}
       canVote={canVote(poster)}
       isVoted={!!votes.find(v => v.presentation_id === poster.id)}
       toggleVote={toggleVote}
@@ -61,7 +44,6 @@ const PosterGrid = ({ allPosters, posters, showDetailPage = null, votingAllowed,
 };
 
 PosterGrid.propTypes = {
-  allPosters: PropTypes.array.isRequired,
   posters: PropTypes.array.isRequired,
   showDetailPage: PropTypes.func,
   votingAllowed: PropTypes.bool.isRequired,

--- a/src/model/VotingPeriod.js
+++ b/src/model/VotingPeriod.js
@@ -9,10 +9,8 @@ export const VotingPeriod = (params, now) => {
     endDate: isValidEndDate ? params.endDate : null,
     attendeeVotes: (Number.isInteger(params.attendeeVotes) || params.attendeeVotes === Infinity) && params.attendeeVotes >= 0 ? params.attendeeVotes : null,
     maxAttendeeVotes: (Number.isInteger(params.maxAttendeeVotes) || params.maxAttendeeVotes === Infinity) && params.maxAttendeeVotes >= 0 ? params.maxAttendeeVotes === 0 ? Infinity : params.maxAttendeeVotes : null,
-    phase: // if no valid start date and end date, seems you can still vote in api
-           // removing valid dates check
-           //isValidStartDate && isValidEndDate && isValidUTC(now) ?
-           isValidUTC(now) ?
+    phase: // if no valid start date or end date, seems you can still vote in api
+           (isValidStartDate || isValidEndDate) && isValidUTC(now) ?
            getVotingPeriodPhase({ startDate: params.startDate, endDate: params.endDate }, now) :
            Number.isInteger(params.phase) && (params.phase === PHASES.BEFORE || params.phase === PHASES.DURING || params.phase === PHASES.AFTER) ? params.phase : null,
     get remainingVotes() {

--- a/src/model/VotingPeriod.js
+++ b/src/model/VotingPeriod.js
@@ -1,0 +1,32 @@
+import { PHASES } from '../utils/phasesUtils';
+import { isValidUTC, getVotingPeriodPhase } from '../utils/phasesUtils';
+
+export const VotingPeriod = (params, now) => {
+  const isValidStartDate = isValidUTC(params.startDate);
+  const isValidEndDate = isValidUTC(params.endDate);
+  return {
+    startDate: isValidStartDate ? params.startDate : null,
+    endDate: isValidEndDate ? params.endDate : null,
+    attendeeVotes: (Number.isInteger(params.attendeeVotes) || params.attendeeVotes === Infinity) && params.attendeeVotes >= 0 ? params.attendeeVotes : null,
+    maxAttendeeVotes: (Number.isInteger(params.maxAttendeeVotes) || params.maxAttendeeVotes === Infinity) && params.maxAttendeeVotes >= 0 ? params.maxAttendeeVotes === 0 ? Infinity : params.maxAttendeeVotes : null,
+    phase: // if no valid start date and end date, seems you can still vote in api
+           // removing valid dates check
+           //isValidStartDate && isValidEndDate && isValidUTC(now) ?
+           isValidUTC(now) ?
+           getVotingPeriodPhase({ startDate: params.startDate, endDate: params.endDate }, now) :
+           Number.isInteger(params.phase) && (params.phase === PHASES.BEFORE || params.phase === PHASES.DURING || params.phase === PHASES.AFTER) ? params.phase : null,
+    get remainingVotes() {
+      if (this.attendeeVotes === this.maxAttendeeVotes === null) return null;
+      if (this.attendeeVotes === null && this.maxAttendeeVotes !== null) return this.maxAttendeeVotes;
+      return this.maxAttendeeVotes - this.attendeeVotes;
+    },
+    set addVotes(value) {
+      if (!Number.isInteger(value) && value <= 0) return;
+      this.attendeeVotes = this.attendeeVotes === null ? value : this.attendeeVotes + value;
+    },
+    set substractVotes(value) {
+      if (!Number.isInteger(value) && value <= 0 || this.attendeeVotes === null) return;
+      this.attendeeVotes = this.attendeeVotes - value;
+    }
+  }
+};

--- a/src/reducers/clock-reducer.js
+++ b/src/reducers/clock-reducer.js
@@ -59,10 +59,10 @@ const clockReducer = (state = DEFAULT_STATE, action) => {
     case EVENT_PHASE_BEFORE: {
       let eventsPhases = [...new Set(state.events_phases.filter(s => s.id !== payload.id))];
       return { ...state, events_phases: [...eventsPhases, payload] };
-    }    
+    }
     default:
       return state;
   }
 };
 
-export default clockReducer
+export default clockReducer;

--- a/src/reducers/presentations-reducer.js
+++ b/src/reducers/presentations-reducer.js
@@ -42,7 +42,7 @@ const voteablePresentations = (state = DEFAULT_VOTEABLE_PRESENTATIONS_STATE, act
       // pre filter by user access levels
       let filteredEvents = filterEventsByAccessLevels(allVoteablePresentations, currentUserProfile);
       // suffle
-      //filteredEvents = filteredEvents.map((a) => [Math.random(),a]).sort((a,b) => a[0]-b[0]).map((a) => a[1]);
+      filteredEvents = filteredEvents.map((a) => [Math.random(),a]).sort((a,b) => a[0]-b[0]).map((a) => a[1]);
       return { ...state,
         ssrPresentations: filteredEvents,
         allPresentations: filteredEvents,

--- a/src/reducers/user-reducer.js
+++ b/src/reducers/user-reducer.js
@@ -1,3 +1,5 @@
+import { reduceReducers } from '../utils/reducer-utils';
+
 import { LOGOUT_USER } from "openstack-uicore-foundation/lib/actions";
 
 import {
@@ -96,24 +98,26 @@ const attendeeReducer = (state, action) => {
       return { ...state, attendee: ticket?.owner ?? null };
     }
     case CAST_PRESENTATION_VOTE_RESPONSE: {
-      const { attendee} = state;
-      if(!attendee) return state;
-      let presentation_votes = attendee;
+      const { attendee } = state;
+      if (!attendee) return state;
+      const { presentation_votes } = attendee;
       const { response: vote } = payload;
       // remove 'local vote' vote before adding real vote
       const filteredVotes = presentation_votes.filter(v => v.presentation_id !== vote.presentation_id);
       return { ...state, attendee: { ...state.attendee, presentation_votes: [...filteredVotes, vote] } };
     }
     case UNCAST_PRESENTATION_VOTE_RESPONSE: {
-      const { attendee: { presentation_votes }} = state;
+      const { attendee } = state;
+      if (!attendee) return state;
+      const { presentation_votes } = attendee;
       const { presentation } = payload;
       const newVotes = [...presentation_votes.filter(v => v.presentation_id !== presentation.id)];
       return { ...state, attendee: { ...state.attendee, presentation_votes: newVotes } };
     }
     case TOGGLE_PRESENTATION_VOTE: {
-      const { attendee} = state;
-      if(!attendee) return state;
-      let presentation_votes = attendee;
+      const { attendee } = state;
+      if (!attendee) return state;
+      const { presentation_votes } = attendee;
       const { presentation, isVoted } = payload;
       let newVotes;
       if (isVoted) {
@@ -128,8 +132,5 @@ const attendeeReducer = (state, action) => {
       return state;
   }
 };
-
-const reduceReducers = (...reducers) => (state, action) =>
-    reducers.reduce((acc, r) => r(acc, action), state);
 
 export default reduceReducers(attendeeReducer, userReducer);

--- a/src/reducers/user-reducer.js
+++ b/src/reducers/user-reducer.js
@@ -1,6 +1,6 @@
 import { reduceReducers } from '../utils/reducer-utils';
 
-import { LOGOUT_USER } from "openstack-uicore-foundation/lib/actions";
+import { LOGOUT_USER } from 'openstack-uicore-foundation/lib/actions';
 
 import {
   GET_DISQUS_SSO,
@@ -133,4 +133,4 @@ const attendeeReducer = (state, action) => {
   }
 };
 
-export default reduceReducers(attendeeReducer, userReducer);
+export default reduceReducers(userReducer, attendeeReducer);

--- a/src/templates/poster-detail-page.js
+++ b/src/templates/poster-detail-page.js
@@ -91,6 +91,8 @@ export const PosterDetailPageTemplate = class extends React.Component {
       recommendedPosters,
       isAuthorized,
       hasTicket,
+      attendee,
+      votingPeriods,
     } = this.props;
     // get current event phase
     const currentPhase = eventsPhases.find((e) => parseInt(e.id) === parseInt(presentationId))?.phase;
@@ -171,7 +173,11 @@ export const PosterDetailPageTemplate = class extends React.Component {
             <div className="column is-three-quarters is-full-mobile">
               <div className="px-5 py-0">
                 <PosterDescription
+                  allPosters={allPosters}
                   poster={poster}
+                  votingAllowed={!!attendee}
+                  votingPeriods={votingPeriods}
+                  votes={votes}
                   isVoted={!!votes.find(v => v.presentation_id === poster.id)}
                   toggleVote={this.toggleVote}
                 />
@@ -179,7 +185,15 @@ export const PosterDetailPageTemplate = class extends React.Component {
               <div className="px-5 py-0">
                 <PosterNavigation allPosters={allPosters} poster={poster} />
                 <div className="mt-5 mb-5 mx-0"><b>More like this</b></div>
-                <PosterGrid posters={recommendedPosters} canVote={true} votes={votes} toggleVote={this.toggleVote} showDetailPage={this.goToDetails} showDetail={true}/>
+                <PosterGrid
+                  allPosters={allPosters}
+                  posters={recommendedPosters}
+                  votingAllowed={!!attendee}
+                  votingPeriods={votingPeriods}
+                  votes={votes}
+                  toggleVote={this.toggleVote}
+                  showDetailPage={this.goToDetails}
+                />
               </div>
               <div className="is-hidden-tablet">
                 <DisqusComponent
@@ -235,6 +249,8 @@ const PosterDetailPage = ({
   getAllVoteablePresentations,
   hasTicket,
   isAuthorized,
+  attendee,
+  votingPeriods,
 }) => {
   return (
     <Layout location={location}>
@@ -265,6 +281,8 @@ const PosterDetailPage = ({
         getAllVoteablePresentations={getAllVoteablePresentations}
         hasTicket={hasTicket}
         isAuthorized={isAuthorized}
+        attendee={attendee}
+        votingPeriods={votingPeriods}
       />
     </Layout>
   );
@@ -280,6 +298,8 @@ PosterDetailPage.propTypes = {
   castPresentationVote: PropTypes.func,
   uncastPresentationVote: PropTypes.func,
   getDisqusSSO: PropTypes.func,
+  attendee: PropTypes.object,
+  votingPeriods: PropTypes.object,
 };
 
 PosterDetailPageTemplate.propTypes = {
@@ -292,6 +312,8 @@ PosterDetailPageTemplate.propTypes = {
   castPresentationVote: PropTypes.func,
   uncastPresentationVote: PropTypes.func,
   getDisqusSSO: PropTypes.func,
+  attendee: PropTypes.object,
+  votingPeriods: PropTypes.object,
 };
 
 const mapStateToProps = ({ summitState, userState, clockState, presentationsState }) => ({
@@ -305,7 +327,9 @@ const mapStateToProps = ({ summitState, userState, clockState, presentationsStat
   nowUtc: clockState.nowUtc,
   allPosters: presentationsState.voteablePresentations.allPresentations,
   recommendedPosters: presentationsState.voteablePresentations.recommendedPresentations,
+  attendee: userState.attendee,
   votes: userState.attendee?.presentation_votes ?? [],
+  votingPeriods: presentationsState.votingPeriods,
 });
 
 export default connect(mapStateToProps, {

--- a/src/templates/poster-detail-page.js
+++ b/src/templates/poster-detail-page.js
@@ -173,7 +173,6 @@ export const PosterDetailPageTemplate = class extends React.Component {
             <div className="column is-three-quarters is-full-mobile">
               <div className="px-5 py-0">
                 <PosterDescription
-                  allPosters={allPosters}
                   poster={poster}
                   votingAllowed={!!attendee}
                   votingPeriods={votingPeriods}
@@ -186,7 +185,6 @@ export const PosterDetailPageTemplate = class extends React.Component {
                 <PosterNavigation allPosters={allPosters} poster={poster} />
                 <div className="mt-5 mb-5 mx-0"><b>More like this</b></div>
                 <PosterGrid
-                  allPosters={allPosters}
                   posters={recommendedPosters}
                   votingAllowed={!!attendee}
                   votingPeriods={votingPeriods}

--- a/src/templates/posters-page.js
+++ b/src/templates/posters-page.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { navigate } from "gatsby";
 import Layout from '../components/Layout';
@@ -17,7 +16,6 @@ import {
 import {
   castPresentationVote,
   uncastPresentationVote
-
 } from '../actions/user-actions';
 
 import { filterByTrackGroup } from '../utils/filterUtils';
@@ -32,7 +30,6 @@ const PostersPage = ({
                       setInitialDataSet,
                       getAllVoteablePresentations,
                       posters,
-                      allPosters,
                       castPresentationVote,
                       uncastPresentationVote,
                       votingPeriods,
@@ -92,7 +89,6 @@ const PostersPage = ({
       <div className={`${styles.wrapper} ${showFilters ? styles.showFilters : ''}`}>
         <div className={styles.postersWrapper}>
           <PosterGrid
-            allPosters={allPosters}
             posters={postersByTrackGroup}
             showDetailPage={(posterId) => navigate(`/a/poster/${posterId}`)}
             votingPeriods={votingPeriods}
@@ -111,12 +107,9 @@ const PostersPage = ({
   );
 };
 
-PostersPage.propTypes = {};
-
 const mapStateToProps = ({ settingState, presentationsState, userState, summitState }) => ({
   pagesSettings: [...settingState.posterPagesSettings.posterPages],
   posters: presentationsState.voteablePresentations.filteredPresentations,
-  allPosters: presentationsState.voteablePresentations.allPresentations,
   allBuildTimePosters: presentationsState.voteablePresentations.ssrPresentations,
   votingPeriods: presentationsState.votingPeriods,
   attendee: userState.attendee,
@@ -131,5 +124,5 @@ export default connect(mapStateToProps, {
   getAllVoteablePresentations,
   castPresentationVote,
   uncastPresentationVote,
-  updateFilter,
+  updateFilter
 })(PostersPage);

--- a/src/templates/posters-page.js
+++ b/src/templates/posters-page.js
@@ -39,6 +39,7 @@ const PostersPage = ({
                       attendee,
                       votes,
                       summit,
+                      allBuildTimePosters,
                       filters,
                       updateFilter,
                       colorSettings
@@ -46,7 +47,7 @@ const PostersPage = ({
 
   const [showFilters, setShowfilters] = useState(false);
   const [postersByTrackGroup, setPostersByTrackGroup] = useState(posters);
-  const [allPostersByTrackGroup, setAllPostersByTrackGroup] = useState(allPosters);
+  const [allBuildTimePostersByTrackGroup, setAllBuildTimePostersByTrackGroup] = useState(allBuildTimePosters);
   const [pageSettings] = useState(pagesSettings.find(pps => pps.trackGroupId === parseInt(trackGroupId)));
 
   useEffect(() => {
@@ -58,8 +59,8 @@ const PostersPage = ({
   }, [posters, trackGroupId]);
 
   useEffect(() => {
-    setAllPostersByTrackGroup(filterByTrackGroup(allPosters, parseInt(trackGroupId)));
-  }, [allPosters, trackGroupId]);
+    setAllBuildTimePostersByTrackGroup(filterByTrackGroup(allBuildTimePosters, parseInt(trackGroupId)));
+  }, [allBuildTimePosters, trackGroupId]);
 
   const toggleVote = (presentation, isVoted) => {
     isVoted ? castPresentationVote(presentation) : uncastPresentationVote(presentation);
@@ -67,8 +68,8 @@ const PostersPage = ({
 
   const filterProps = {
     summit,
-    events: allPostersByTrackGroup,
-    allEvents: allPostersByTrackGroup,
+    events: allBuildTimePostersByTrackGroup,
+    allEvents: allBuildTimePostersByTrackGroup,
     filters,
     triggerAction: (action, payload) => {
       updateFilter(payload);
@@ -91,10 +92,11 @@ const PostersPage = ({
       <div className={`${styles.wrapper} ${showFilters ? styles.showFilters : ''}`}>
         <div className={styles.postersWrapper}>
           <PosterGrid
+            allPosters={allPosters}
             posters={postersByTrackGroup}
             showDetailPage={(posterId) => navigate(`/a/poster/${posterId}`)}
             votingPeriods={votingPeriods}
-            vottingAllowed={!!attendee}
+            votingAllowed={!!attendee}
             votes={votes}
             toggleVote={toggleVote}
           />
@@ -114,7 +116,8 @@ PostersPage.propTypes = {};
 const mapStateToProps = ({ settingState, presentationsState, userState, summitState }) => ({
   pagesSettings: [...settingState.posterPagesSettings.posterPages],
   posters: presentationsState.voteablePresentations.filteredPresentations,
-  allPosters: presentationsState.voteablePresentations.ssrPresentations,
+  allPosters: presentationsState.voteablePresentations.allPresentations,
+  allBuildTimePosters: presentationsState.voteablePresentations.ssrPresentations,
   votingPeriods: presentationsState.votingPeriods,
   attendee: userState.attendee,
   votes: userState.attendee?.presentation_votes ?? [],

--- a/src/templates/posters-page.js
+++ b/src/templates/posters-page.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { navigate } from "gatsby";
@@ -28,25 +28,26 @@ import AttendanceTrackerComponent from "../components/AttendanceTrackerComponent
 const PostersPage = ({
                       location,
                       trackGroupId,
+                      pagesSettings,
                       setInitialDataSet,
                       getAllVoteablePresentations,
                       posters,
-                      votes,
+                      allPosters,
                       castPresentationVote,
                       uncastPresentationVote,
+                      votingPeriods,
+                      attendee,
+                      votes,
                       summit,
-                      allPosters,
                       filters,
                       updateFilter,
-                      colorSettings,
-                      pagesSettings
+                      colorSettings
                     }) => {
 
-  const [canVote, setCanVote] = useState(true);
   const [showFilters, setShowfilters] = useState(false);
   const [postersByTrackGroup, setPostersByTrackGroup] = useState(posters);
   const [allPostersByTrackGroup, setAllPostersByTrackGroup] = useState(allPosters);
-  const [pageSettings, setPageSetting] = useState(pagesSettings.find(pps => pps.trackGroupId === parseInt(trackGroupId)));
+  const [pageSettings] = useState(pagesSettings.find(pps => pps.trackGroupId === parseInt(trackGroupId)));
 
   useEffect(() => {
     setInitialDataSet().then(() => getAllVoteablePresentations());
@@ -92,7 +93,9 @@ const PostersPage = ({
           <PosterGrid
             posters={postersByTrackGroup}
             showDetailPage={(posterId) => navigate(`/a/poster/${posterId}`)}
-            canVote={canVote} votes={votes}
+            votingPeriods={votingPeriods}
+            vottingAllowed={!!attendee}
+            votes={votes}
             toggleVote={toggleVote}
           />
         </div>
@@ -108,14 +111,16 @@ const PostersPage = ({
 
 PostersPage.propTypes = {};
 
-const mapStateToProps = ({presentationsState, userState, summitState, settingState}) => ({
+const mapStateToProps = ({ settingState, presentationsState, userState, summitState }) => ({
+  pagesSettings: [...settingState.posterPagesSettings.posterPages],
   posters: presentationsState.voteablePresentations.filteredPresentations,
   allPosters: presentationsState.voteablePresentations.ssrPresentations,
-  filters: presentationsState.voteablePresentations.filters,
-  votes: userState.attendee?.presentation_votes?? [],
+  votingPeriods: presentationsState.votingPeriods,
+  attendee: userState.attendee,
+  votes: userState.attendee?.presentation_votes ?? [],
   summit: summitState.summit,
-  colorSettings: settingState.colorSettings,
-  pagesSettings: [...settingState.posterPagesSettings.posterPages],
+  filters: presentationsState.voteablePresentations.filters,
+  colorSettings: settingState.colorSettings
 });
 
 export default connect(mapStateToProps, {

--- a/src/utils/phasesUtils.js
+++ b/src/utils/phasesUtils.js
@@ -6,7 +6,7 @@ export const PHASES = {
   AFTER: 1,
 };
 
-export const isValidUTC = (timestamp) => (new Date(timestamp)).getTime() > 0;
+export const isValidUTC = (timestamp) => typeof timestamp === 'number';
 
 export const getSummitPhase = function (summit, now) {
   if (!summit) return null;
@@ -42,9 +42,7 @@ export const getVotingPeriodPhase = (votingPeriod, now) => {
   const isValidEndDate = isValidUTC(endDate);
 
   if ((!isValidStartDate && isValidEndDate && endDate > now) ||
-      (!isValidEndDate && isValidStartDate && startDate < now) ||
-      // if no valid start date and end date, seems you can still vote in api, resolving as DURING
-      (!isValidStartDate && !isValidEndDate))
+      (!isValidEndDate && isValidStartDate && startDate < now))
     return PHASES.DURING;
 
   return isValidStartDate && startDate < now && isValidEndDate && endDate > now ? PHASES.DURING :

--- a/src/utils/phasesUtils.js
+++ b/src/utils/phasesUtils.js
@@ -22,11 +22,26 @@ export const getSummitPhase = function (summit, now) {
 };
 
 export const getEventPhase = function (event, now) {
-  let { start_date, end_date } = event;
+  const { start_date, end_date } = event;
 
   return start_date < now && end_date > now ? PHASES.DURING
       :
       start_date > now ? PHASES.BEFORE
         :
         end_date < now ? PHASES.AFTER : null;
+};
+
+export const getVotingPeriodPhase = (votingPeriod, now) => {
+  const { startDate, endDate } = votingPeriod;
+
+  if ((startDate === endDate === null) ||
+     (startDate === null && endDate > now) ||
+     (endDate === null && startDate < now))
+    return PHASES.DURING;
+
+  return startDate < now && endDate > now ? PHASES.DURING
+      :
+      startDate > now ? PHASES.BEFORE
+        :
+        endDate < now ? PHASES.AFTER : null;
 };

--- a/src/utils/reducer-utils.js
+++ b/src/utils/reducer-utils.js
@@ -1,0 +1,2 @@
+export const reduceReducers = (...reducers) => (state, action) =>
+    reducers.reduce((acc, r) => r(acc, action), state);

--- a/src/utils/voting-utils.js
+++ b/src/utils/voting-utils.js
@@ -1,6 +1,4 @@
-export const TRACK_GROUP_CLASS_NAME = 'PresentationCategoryGroup';
-
-export const calculateVotesPerTrackGroup = (presentations, votes) => {
+export const mapVotesPerTrackGroup = (votes, presentations) => {
   const votesPerTrackGroup = {};
   votes.forEach(v => {
     const presentation = presentations.find(p => p.id === v.presentation_id);
@@ -12,13 +10,4 @@ export const calculateVotesPerTrackGroup = (presentations, votes) => {
       });
   });
   return votesPerTrackGroup;
-};
-
-export const calculateRemaingVotes = (votingPeriod = {}, votesPerTrackGroup) => {
-  const remainingVotes = {};
-  Object.entries(votingPeriod).forEach(entry => {
-    const [trackGroupId, votingPeriod] = entry;
-    remainingVotes[trackGroupId] = votingPeriod.maxAttendeeVotes === 0 ? Infinity : votingPeriod.maxAttendeeVotes - (votesPerTrackGroup[trackGroupId] ?? 0);
-  });
-  return remainingVotes;
 };

--- a/src/utils/voting-utils.js
+++ b/src/utils/voting-utils.js
@@ -1,14 +1,5 @@
 export const TRACK_GROUP_CLASS_NAME = 'PresentationCategoryGroup';
 
-export const calculateRemaingVotes = (votingPeriod = {}, votesPerTrackGroup) => {
-  const remainingVotes = {};
-  Object.entries(votingPeriod).forEach(entry => {
-    const [trackGroupId, votingPeriod] = entry;
-    remainingVotes[trackGroupId] = votingPeriod.maxAttendeeVotes === 0 ? Infinity : votingPeriod.maxAttendeeVotes - (votesPerTrackGroup[trackGroupId] ?? 0);
-  });
-  return remainingVotes;
-};
-
 export const calculateVotesPerTrackGroup = (presentations, votes) => {
   const votesPerTrackGroup = {};
   votes.forEach(v => {
@@ -21,4 +12,13 @@ export const calculateVotesPerTrackGroup = (presentations, votes) => {
       });
   });
   return votesPerTrackGroup;
+};
+
+export const calculateRemaingVotes = (votingPeriod = {}, votesPerTrackGroup) => {
+  const remainingVotes = {};
+  Object.entries(votingPeriod).forEach(entry => {
+    const [trackGroupId, votingPeriod] = entry;
+    remainingVotes[trackGroupId] = votingPeriod.maxAttendeeVotes === 0 ? Infinity : votingPeriod.maxAttendeeVotes - (votesPerTrackGroup[trackGroupId] ?? 0);
+  });
+  return remainingVotes;
 };

--- a/src/utils/voting-utils.js
+++ b/src/utils/voting-utils.js
@@ -1,0 +1,24 @@
+export const TRACK_GROUP_CLASS_NAME = 'PresentationCategoryGroup';
+
+export const calculateRemaingVotes = (votingPeriod = {}, votesPerTrackGroup) => {
+  const remainingVotes = {};
+  Object.entries(votingPeriod).forEach(entry => {
+    const [trackGroupId, votingPeriod] = entry;
+    remainingVotes[trackGroupId] = votingPeriod.maxAttendeeVotes === 0 ? Infinity : votingPeriod.maxAttendeeVotes - (votesPerTrackGroup[trackGroupId] ?? 0);
+  });
+  return remainingVotes;
+};
+
+export const calculateVotesPerTrackGroup = (presentations, votes) => {
+  const votesPerTrackGroup = {};
+  votes.forEach(v => {
+    const presentation = presentations.find(p => p.id === v.presentation_id);
+    if (presentation && presentation.track && presentation.track.track_groups) 
+      presentation.track.track_groups.forEach(trackGroupId => {
+        if (!votesPerTrackGroup[trackGroupId])
+          votesPerTrackGroup[trackGroupId] = 0;
+        votesPerTrackGroup[trackGroupId] += 1;
+      });
+  });
+  return votesPerTrackGroup;
+};


### PR DESCRIPTION
Implements, in presentation reducer, track group voting periods which updates its phase based on clock.
Sets can vote poster based on voting period phase and calculation of remaining votes of voting period.
Calculation of remaining votes its currently done on component; after implementation thought it would be better to have on reducer. 
