### PR TITLE
Added focus indicator to links and buttons for keyboard navigation

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,4 +1,5 @@
 import './src/utils/envVariables'
+import 'what-input'
 import ReduxWrapper from "./src/state/ReduxWrapper"
 import colors from './src/content/colors.json'
 export const wrapRootElement = ReduxWrapper;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "jsdom": "^16.2.2",
     "lite-schedule-widget": "^1.0.14",
     "live-event-widget": "^2.0.15",
-    "localforage": "^1.10.0",
     "lodash": "^4.17.19",
     "markdown-it": "^12.0.0",
     "moment": "^2.27.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jsdom": "^16.2.2",
     "lite-schedule-widget": "^1.0.14",
     "live-event-widget": "^2.0.15",
+    "localforage": "^1.10.0",
     "lodash": "^4.17.19",
     "markdown-it": "^12.0.0",
     "moment": "^2.27.0",
@@ -98,6 +99,7 @@
     "video.js": "^7.8.2",
     "videojs-mux": "^3.1.0",
     "videojs-youtube": "^2.6.1",
+    "what-input": "^5.2.10",
     "xmlhttprequest": "^1.8.0",
     "react-block-image": "^1.0.0",
     "react-medium-image-zoom": "^4.3.5"

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -54,6 +54,30 @@ body {
   height: 100%;
 }
 
+*:focus,
+.focus {
+  outline: 3px solid transparent !important;
+    box-shadow:  0 0 0 3px #fff, 0 0 0 6px #333 !important;
+}
+*:focus-visible {
+  outline: none !important;
+}
+
+/*
+  This will hide the focus indicator if the element receives focus via the mouse,
+  but it will still show up on keyboard focus.
+*/
+html:not([data-whatintent=keyboard]) *:focus,
+html:not([data-whatintent=keyboard]) .focus {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+/* overrides Bulma focus style */
+.button:focus {
+  color: $color_text_light !important;
+}
+
 label {
   font-weight: 300;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19519,7 +19519,7 @@ websocket@^1.0.34:
     utf-8-validate "^5.0.2"
     yaeti "^0.0.6"
 
-what-input@^5.1.4:
+what-input@^5.1.4, what-input@^5.2.10:
   version "5.2.10"
   resolved "https://registry.yarnpkg.com/what-input/-/what-input-5.2.10.tgz#f79f5b65cf95d75e55e6d580bb0a6b98174cad4e"
   integrity sha512-7AQoIMGq7uU8esmKniOtZG3A+pzlwgeyFpkS3f/yzRbxknSL68tvn5gjE6bZ4OMFxCPjpaBd2udUTqlZ0HwrXQ==


### PR DESCRIPTION
**What's broken**

Whe user navigates the page using keyboard (e.g. tabbing accross links), we must show an indicator of the focused element. This indicator is currently missing on the page.

**What kind of change does this PR introduce?**

We added a module that detects when user interacts using a keyboard to show a focus indicator that's not shown when user interacts using a mouse or touch screen.

**Does this PR introduce a breaking change?**

`yarn install` is needed in order to add the new dependency.
