### PR TITLE
ProfilePopupComponent: focus is now scoped to modal until closed

### DIFF
--- a/src/components/ProfilePopupComponent.js
+++ b/src/components/ProfilePopupComponent.js
@@ -10,6 +10,7 @@ import styles from '../styles/profile.module.scss'
 const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfile, changePicture, changeProfile, fromFullProfile }) => {
 
   const editorRef = useRef(null);
+  const pictureIconRef = useRef(null)
 
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
@@ -64,6 +65,14 @@ const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfil
               userProfile.linkedin,
               userProfile.twitter_name
   ]);
+
+  useEffect(() => {
+    if (pictureIconRef) {
+      window.setTimeout(function () {
+        pictureIconRef.current.focus();
+      }, 0);
+    }
+  }, [pictureIconRef])
 
   const handleNewImage = (e) => {
     setImage(e.target.files[0]);
@@ -136,7 +145,7 @@ const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfil
       <div className={`${styles.modal} ${showProfile ? styles.isActive : ''}`}>
         <div className={`${styles.modalCard} ${styles.profilePopup}`}>
           <AjaxLoader relative={true} color={'#ffffff'} show={idpLoading} size={120} />
-          <header className={`${styles.modalCardHead}`}>
+          <header className={`${styles.modalCardHead}`} tabIndex='-1' ref={pictureIconRef}>
             <p className={`${styles.modalCardTitle}`}>Edit profile</p>
             <button className="link" onClick={() => closePopup()}>
               <i className={`${styles.closeIcon} fa fa-times icon`} />

--- a/src/components/ProfilePopupComponent.js
+++ b/src/components/ProfilePopupComponent.js
@@ -10,7 +10,8 @@ import styles from '../styles/profile.module.scss'
 const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfile, changePicture, changeProfile, fromFullProfile }) => {
 
   const editorRef = useRef(null);
-  const pictureIconRef = useRef(null)
+  const modalHeaderRef = useRef(null)
+  const modalRef = useRef(null)
 
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
@@ -67,12 +68,45 @@ const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfil
   ]);
 
   useEffect(() => {
-    if (pictureIconRef) {
+    if (modalHeaderRef) {
       window.setTimeout(function () {
-        pictureIconRef.current.focus();
+        modalHeaderRef.current.focus();
       }, 0);
     }
-  }, [pictureIconRef])
+  }, [modalHeaderRef])
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleUserKeyPress);
+
+    return () => {
+      window.removeEventListener('keydown', handleUserKeyPress);
+    };
+  }, []);
+
+  const handleUserKeyPress = (e) => {
+    const focusable = modalRef.current.querySelectorAll('button, input, [tabindex]:not([tabindex="-1"])');
+    const firstFocusable = focusable[0];
+    const lastFocusable = focusable[focusable.length - 1];
+    const KEYCODE_TAB = 9;
+    const isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
+
+    if (!isTabPressed) {
+      return;
+    }
+
+    if ( e.shiftKey ) /* shift + tab */ {
+      if (document.activeElement === firstFocusable) {
+        lastFocusable.focus();
+        e.preventDefault();
+      }
+    } else /* tab */ {
+      if (document.activeElement === lastFocusable) {
+        firstFocusable.focus();
+        e.preventDefault();
+      }
+    }
+  }
+
 
   const handleNewImage = (e) => {
     setImage(e.target.files[0]);
@@ -142,10 +176,10 @@ const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfil
   };
 
   return (
-      <div className={`${styles.modal} ${showProfile ? styles.isActive : ''}`}>
+      <div className={`${styles.modal} ${showProfile ? styles.isActive : ''}`} ref={modalRef}>
         <div className={`${styles.modalCard} ${styles.profilePopup}`}>
           <AjaxLoader relative={true} color={'#ffffff'} show={idpLoading} size={120} />
-          <header className={`${styles.modalCardHead}`} tabIndex='-1' ref={pictureIconRef}>
+          <header className={`${styles.modalCardHead}`} tabIndex='-1' ref={modalHeaderRef}>
             <p className={`${styles.modalCardTitle}`}>Edit profile</p>
             <button className="link" onClick={() => closePopup()}>
               <i className={`${styles.closeIcon} fa fa-times icon`} />

--- a/src/components/ProfilePopupComponent.js
+++ b/src/components/ProfilePopupComponent.js
@@ -84,7 +84,7 @@ const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfil
   }, []);
 
   const handleUserKeyPress = (e) => {
-    const focusable = modalRef.current.querySelectorAll('button, input, [tabindex]:not([tabindex="-1"])');
+    const focusable = modalRef.current.querySelectorAll('button, input, a, textarea, select, [tabindex]:not([tabindex="-1"])');
     const firstFocusable = focusable[0];
     const lastFocusable = focusable[focusable.length - 1];
     const KEYCODE_TAB = 9;
@@ -179,8 +179,8 @@ const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfil
       <div className={`${styles.modal} ${showProfile ? styles.isActive : ''}`} ref={modalRef}>
         <div className={`${styles.modalCard} ${styles.profilePopup}`}>
           <AjaxLoader relative={true} color={'#ffffff'} show={idpLoading} size={120} />
-          <header className={`${styles.modalCardHead}`} tabIndex='-1' ref={modalHeaderRef}>
-            <p className={`${styles.modalCardTitle}`}>Edit profile</p>
+          <header className={`${styles.modalCardHead}`}>
+            <p className={`${styles.modalCardTitle}`} tabIndex='-1' ref={modalHeaderRef}>Edit profile</p>
             <button className="link" onClick={() => closePopup()}>
               <i className={`${styles.closeIcon} fa fa-times icon`} />
             </button>


### PR DESCRIPTION
**What's broken**

When clicking the profile picture button, a profile modal is opened but focus remains on the pp button. 
When navigating inside the modal (tab / shift + tab) focus would leave the scope and start focusing elements outside the modal.

**What kind of change does this PR introduce?**

Autofocusing the header <p> when opening the modal. Limiting the focus to a circular navigation inside the desired scope, until the modal is closed.

**Does this PR introduce a breaking change?**

This PR doesn't introduce any breaking change.