### PR TITLE
Fixing double load for recommended presentations

### DIFF
--- a/src/reducers/presentations-reducer.js
+++ b/src/reducers/presentations-reducer.js
@@ -83,7 +83,8 @@ const voteablePresentations = (state = DEFAULT_VOTEABLE_PRESENTATIONS_STATE, act
       return { ...state, detailedPresentation: presentation };
     }
     case GET_RECOMMENDED_PRESENTATIONS: {
-      const recommended = [...payload.response.data.slice(0,-2)];
+      let recommended = [...payload.response.data.filter(e => e.id !== state.detailedPresentation.id)];
+      recommended = [...recommended.slice(0, recommended.length === 5 ? -2 : -1)];
       return { ...state, loading: false, recommendedPresentations: recommended };
     }
     case START_LOADING:

--- a/src/templates/poster-detail-page.js
+++ b/src/templates/poster-detail-page.js
@@ -107,7 +107,7 @@ export const PosterDetailPageTemplate = class extends React.Component {
     }
 
     // authz ( todo : refactor WithBadgeRoute to be more generic)
-    const hasBadgeForEvent = isAuthorized || (poster.id && user && isAuthorizedBadge(poster, user.summit_tickets));
+    const hasBadgeForEvent = isAuthorized || (poster.id && user?.userProfile && isAuthorizedBadge(poster, user?.userProfile?.summit_tickets));
     const userIsAuthz = hasTicket || isAuthorized;
 
     if (!userIsAuthz || !hasBadgeForEvent) {
@@ -305,7 +305,7 @@ const mapStateToProps = ({ summitState, userState, clockState, presentationsStat
   nowUtc: clockState.nowUtc,
   allPosters: presentationsState.voteablePresentations.allPresentations,
   recommendedPosters: presentationsState.voteablePresentations.recommendedPresentations,
-  votes: userState.attendee.presentation_votes,
+  votes: userState.attendee?.presentation_votes ?? [],
 });
 
 export default connect(mapStateToProps, {

--- a/src/templates/poster-detail-page.js
+++ b/src/templates/poster-detail-page.js
@@ -45,7 +45,7 @@ export const PosterDetailPageTemplate = class extends React.Component {
   componentDidUpdate(prevProps, prevState, snapshot) {
     const { presentationId, poster } = this.props;
     const { presentationId: prevPresentationId } = prevProps;
-    if (presentationId !== prevPresentationId || (poster?.id && poster.id !== parseInt(presentationId))) {
+    if (presentationId !== prevPresentationId) {
       this.props.getPresentationById(presentationId);
     }
   }
@@ -107,7 +107,7 @@ export const PosterDetailPageTemplate = class extends React.Component {
     }
 
     // authz ( todo : refactor WithBadgeRoute to be more generic)
-    const hasBadgeForEvent = isAuthorized || (poster.id && user?.userProfile && isAuthorizedBadge(poster, user?.userProfile?.summit_tickets));
+    const hasBadgeForEvent = isAuthorized || (poster.id && user && isAuthorizedBadge(poster, user.summit_tickets));
     const userIsAuthz = hasTicket || isAuthorized;
 
     if (!userIsAuthz || !hasBadgeForEvent) {
@@ -305,7 +305,7 @@ const mapStateToProps = ({ summitState, userState, clockState, presentationsStat
   nowUtc: clockState.nowUtc,
   allPosters: presentationsState.voteablePresentations.allPresentations,
   recommendedPosters: presentationsState.voteablePresentations.recommendedPresentations,
-  votes: userState.attendee?.presentation_votes ?? [],
+  votes: userState.attendee.presentation_votes,
 });
 
 export default connect(mapStateToProps, {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Fixes the double call on detail page navigation
* Fix the duplicate presentation on the widget with the current detailed presentation

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

ref: https://tipit.avaza.com/project/view/295592#!tab=task-pane&task=2835300

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
