### PR TITLE
Fix voting period phase calculation

### DIFF
--- a/src/utils/phasesUtils.js
+++ b/src/utils/phasesUtils.js
@@ -41,8 +41,10 @@ export const getVotingPeriodPhase = (votingPeriod, now) => {
   const isValidStartDate = isValidUTC(startDate);
   const isValidEndDate = isValidUTC(endDate);
 
-  if ((!isValidStartDate && isValidEndDate && endDate > now) ||
-      (!isValidEndDate && isValidStartDate && startDate < now))
+  if (!isValidStartDate && isValidEndDate && endDate > now ||
+      !isValidEndDate && isValidStartDate && startDate < now ||
+      // can vote if no start date end date set; no restrictions
+      !isValidStartDate && !isValidEndDate)
     return PHASES.DURING;
 
   return isValidStartDate && startDate < now && isValidEndDate && endDate > now ? PHASES.DURING :


### PR DESCRIPTION
If no start date and no end date set for track group voting period, set its phase to during.