### PR TITLE
Fixes summit and event phase calculation.

### DIFF
--- a/src/utils/phasesUtils.js
+++ b/src/utils/phasesUtils.js
@@ -15,22 +15,22 @@ export const getSummitPhase = function (summit, now) {
 
   const deltaSummit = MarketingSite.summit_delta_start_time ? MarketingSite.summit_delta_start_time : 0;
 
-  return start_date - deltaSummit < now && end_date > now ? PHASES.DURING
+  return start_date - deltaSummit <= now && end_date > now ? PHASES.DURING
       :
       start_date - deltaSummit > now ? PHASES.BEFORE
         :
-        end_date < now ? PHASES.AFTER : null;
+        end_date <= now ? PHASES.AFTER : null;
 
 };
 
 export const getEventPhase = function (event, now) {
   const { start_date, end_date } = event;
 
-  return start_date < now && end_date > now ? PHASES.DURING
+  return start_date <= now && end_date > now ? PHASES.DURING
       :
       start_date > now ? PHASES.BEFORE
         :
-        end_date < now ? PHASES.AFTER : null;
+        end_date <= now ? PHASES.AFTER : null;
 };
 
 export const getVotingPeriodPhase = (votingPeriod, now) => {


### PR DESCRIPTION
If summit or event start date == now or summit or event end date == now, phase calculation was being changed to null.
Thus, changing state from BEFORE to null then to DURING, or from DURING to null then to AFTER.
This could lead to some component flickering.
This hotfix fixes summit and event phase calculation.