### PR TITLE
Makes posters and poster detail page child of show open route.

### DIFF
--- a/src/pages/a.js
+++ b/src/pages/a.js
@@ -33,9 +33,6 @@ const App = ({ isLoggedUser, user, summit_phase, lastBuild, syncData }) => {
         <Router basepath="/a" >
           <SchedulePage path="/schedule" location={location} />
           <WithAuthRoute path="/" summit_phase={summit_phase} isLoggedIn={isLoggedUser} user={user} location={location}>
-            <PostersPage path="/posters" trackGroupId={0} location={location} />
-            <PostersPage path="/posters/:trackGroupId" location={location} />
-            <PosterDetailPage path="/poster/:presentationId/" isLoggedIn={isLoggedUser} user={user} location={location} />
             <MySchedulePage path="/my-schedule" location={location} summit_phase={summit_phase} isLoggedIn={isLoggedUser} user={user}/>
             <ExtraQuestionsPage path="/extra-questions" isLoggedIn={isLoggedUser} user={user} location={location} />
             <FullProfilePage path="/profile" summit_phase={summit_phase} isLoggedIn={isLoggedUser} user={user} location={location} />
@@ -45,7 +42,10 @@ const App = ({ isLoggedUser, user, summit_phase, lastBuild, syncData }) => {
               </WithBadgeRoute>
               <HomePage path="/" isLoggedIn={isLoggedUser} user={user} location={location} />
               <SponsorPage path="/sponsor/:sponsorId" summit_phase={summit_phase} isLoggedIn={isLoggedUser} user={user} location={location} />
-              <ExpoHallPage path="/sponsors/" summit_phase={summit_phase} isLoggedIn={isLoggedUser} user={user} location={location} />
+              <ExpoHallPage path="/sponsors/" summit_phase={summit_phase} isLoggedIn={isLoggedUser} user={user} location={location} />            
+              <PostersPage path="/posters" trackGroupId={0} location={location} />
+              <PostersPage path="/posters/:trackGroupId" location={location} />
+              <PosterDetailPage path="/poster/:presentationId/" isLoggedIn={isLoggedUser} user={user} location={location} />
             </ShowOpenRoute>
           </WithAuthRoute>
         </Router>


### PR DESCRIPTION
Posters and poster detail pages need to be accessible during show time.
This commit fixes that.