### PR TITLE
Fixes poster order number margin bottom.

### DIFF
--- a/src/components/poster-card/index.module.scss
+++ b/src/components/poster-card/index.module.scss
@@ -59,7 +59,7 @@
     color: #979797;
     font-size: 1.15em;
     font-weight: 700;
-    margin-bottom: -20px;
+    margin-bottom: 5px;
   }
   .footer {
     display: flex;


### PR DESCRIPTION
Fixes [In the poster gallery, not every poster has the number identified under the title](https://tipit.avaza.com/project/view/295592#!tab=task-pane&groupby=ProjectSection&view=vertical&task=2846020&fileview=grid) Avaza ticket 