### PR TITLE
A11y focus ring fix sponsor

### DIFF
--- a/src/styles/sponsor.module.scss
+++ b/src/styles/sponsor.module.scss
@@ -24,6 +24,9 @@
     display: block;
     margin-bottom: 1rem;
   }
+  & > img {
+    margin-bottom: 1rem;
+  }
 }
 
 .small-image-container {


### PR DESCRIPTION
**What's broken**

Sponsors without links lost margin bottom after #281 was merged.

**What kind of change does this PR introduce?**

Added margin bottom to `IMG`.