### PR TITLE
Hotfix/remove bad focus

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -92,11 +92,6 @@ html:not([data-whatintent=keyboard]) .focus {
   z-index: 999;
 }
 
-/* overrides Bulma focus style */
-.button:focus {
-  color: $color_text_light !important;
-}
-
 label {
   font-weight: 300;
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Text on some buttons is unreadable when focused. This fixes it.
![imagen](https://user-images.githubusercontent.com/324617/156610441-58de5833-d6db-4e7d-bf99-479f26e4fef6.png)


**Does this PR introduce a breaking change?**

No. Focused text now remains in whatever color it was before.


