### PR TITLE
Improved style for Skip to content link.

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -79,17 +79,20 @@ html:not([data-whatintent=keyboard]) .focus {
 .skip-to-content:focus {
   width: auto;
   height: auto;
-  padding: 0 5px;
+  padding: 5px 10px;
   margin: 0;
   overflow: hidden;
   clip: auto;
   white-space: nowrap;
   border: 0;
   position: absolute;
-  left: 20px;
+  left: 50%;
   top: 10px;
+  transform: translateX(-50%);
   background-color: white;
   z-index: 999;
+  font-size: 120%;
+  text-decoration: none;
 }
 
 label {


### PR DESCRIPTION
**What's wrong**

Skip to content link is kind of small and placed over the logo.

**What kind of change does this PR introduce?**

Changed style to make it larger and centered:

![imagen](https://user-images.githubusercontent.com/362365/156829864-c36d13da-c5b6-49a8-8f44-665f5bac14a2.png)
