### PR TITLE
Feature/a11y disqus component

### DIFF
--- a/src/components/DisqusComponent.js
+++ b/src/components/DisqusComponent.js
@@ -114,7 +114,7 @@ const DisqusComponent = class extends React.Component {
 
   render() {
 
-    const { title, style, className, disqusSSO, page, hideMobile = null } = this.props;
+    const { title, style, className, disqusSSO, page, hideMobile = null, skipTo } = this.props;
     const { isMobile } = this.state || null;
 
     let disqusConfig = {
@@ -131,7 +131,10 @@ const DisqusComponent = class extends React.Component {
 
     return (
       <div className={className ? className : style ? '' : page === 'marketing-site' ? 'disqus-container-marketing' : 'disqus-container'} style={style}>
-        {title && <span className="navbar-brand title" style={{ paddingLeft: className !== 'disqus-container-home' ? '0px' : ''}}>{title}</span>}
+        <span className="disqus-header" style={{ paddingLeft: className !== 'disqus-container-home' ? '0px' : ''}}>
+          {skipTo && <a className="sr-only skip-to-next" href={skipTo}>Skip to next section</a>}
+          {title && <h2 className="title">{title}</h2>}
+        </span>
         <DiscussionEmbed
           shortname='techweek2022-yahoo'
           config={disqusConfig}

--- a/src/components/DisqusComponent.js
+++ b/src/components/DisqusComponent.js
@@ -130,16 +130,16 @@ const DisqusComponent = class extends React.Component {
     }
 
     return (
-      <div className={className ? className : style ? '' : page === 'marketing-site' ? 'disqus-container-marketing' : 'disqus-container'} style={style}>
-        <span className="disqus-header" style={{ paddingLeft: className !== 'disqus-container-home' ? '0px' : ''}}>
+      <section aria-labelledby={title ? 'disqus-title' : ''} className={className ? className : style ? '' : page === 'marketing-site' ? 'disqus-container-marketing' : 'disqus-container'} style={style}>
+        <div className="disqus-header" style={{ paddingLeft: className !== 'disqus-container-home' ? '0px' : ''}}>
           {skipTo && <a className="sr-only skip-to-next" href={skipTo}>Skip to next section</a>}
-          {title && <h2 className="title">{title}</h2>}
-        </span>
+          {title && <h2 id="disqus-title" className="title">{title}</h2>}
+        </div>
         <DiscussionEmbed
           shortname='techweek2022-yahoo'
           config={disqusConfig}
         />
-      </div>
+      </section>
     )
   }
 

--- a/src/components/DisqusComponent.js
+++ b/src/components/DisqusComponent.js
@@ -113,9 +113,10 @@ const DisqusComponent = class extends React.Component {
   }
 
   render() {
-
     const { title, style, className, disqusSSO, page, hideMobile = null, skipTo } = this.props;
     const { isMobile } = this.state || null;
+    const sectionClass = className ? className : style ? '' : page === 'marketing-site' ? 'disqus-container-marketing' : 'disqus-container';
+    const paddingLeft = className !== 'disqus-container-home' ? '0px' : '15px';
 
     let disqusConfig = {
       url: window.location.href,
@@ -130,8 +131,8 @@ const DisqusComponent = class extends React.Component {
     }
 
     return (
-      <section aria-labelledby={title ? 'disqus-title' : ''} className={className ? className : style ? '' : page === 'marketing-site' ? 'disqus-container-marketing' : 'disqus-container'} style={style}>
-        <div className="disqus-header" style={{ paddingLeft: className !== 'disqus-container-home' ? '0px' : ''}}>
+      <section aria-labelledby={title ? 'disqus-title' : ''} className={sectionClass} style={style}>
+        <div className="disqus-header" style={{ paddingLeft }}>
           {skipTo && <a className="sr-only skip-to-next" href={skipTo}>Skip to next section</a>}
           {title && <h2 id="disqus-title" className="title">{title}</h2>}
         </div>

--- a/src/components/UpcomingEventsComponent.js
+++ b/src/components/UpcomingEventsComponent.js
@@ -52,7 +52,7 @@ const UpcomingEventsComponent = ({
                     href="https://cdnjs.cloudflare.com/ajax/libs/awesome-bootstrap-checkbox/1.0.2/awesome-bootstrap-checkbox.min.css"
                 />
             </Helmet>
-            <div className={className || wrapperClass} style={{ height: 500 }}>
+            <div id="upcoming-events" className={className || wrapperClass} style={{ height: 500 }}>
                 <UpcomingEvents {...componentProps} {...rest} />
             </div>
         </>

--- a/src/templates/home-page.js
+++ b/src/templates/home-page.js
@@ -72,6 +72,7 @@ export const HomePageTemplate = class extends React.Component {
                 summit={summit}
                 className="disqus-container-home"
                 title="Public conversation"
+                skipTo="#upcoming-events"
               />
               <UpcomingEventsComponent
                 onEventClick={(ev) => this.onEventChange(ev)}


### PR DESCRIPTION
**What's broken**

Disqus component has a lot of kinks that should be navigated to reach the next section which could be a pain.
Also the markup of the component lacks of the proper semantics for sectioning and heading.

**What kind of change does this PR introduce?**

We added a link to skip the component and jump to next section and improved the markup semantics.

![imagen](https://user-images.githubusercontent.com/362365/156839139-a4f66f94-4b84-4bbd-be49-663b4710f25f.png)

**What needs to be documented once your changes are merged?**

We added an attribute `skipTo` to the component in order to set the ID of the next section. The value of the attribute should be the next section's ID starting with a `#`. Also, an ID is needed on the next section that match the one set in the attribute `skipTo`.
