### PR TITLE
Removes poster card overlay z-index causing overlapping.

### DIFF
--- a/src/components/poster-card/index.module.scss
+++ b/src/components/poster-card/index.module.scss
@@ -14,7 +14,6 @@
     background-blend-mode: darken;
     transition: 0.3s;
     .overlay {
-      z-index: 100;
       width: 100%;
       height: 100%;
       position: absolute;


### PR DESCRIPTION
Ref: https://tipit.avaza.com/project/view/295592#!tab=task-pane&groupby=ProjectSection&view=vertical&task=2849129&fileview=grid