### PR TITLE
Fixes poster detail rendering when poster fetch erred out.

### DIFF
--- a/src/actions/presentation-actions.js
+++ b/src/actions/presentation-actions.js
@@ -121,7 +121,7 @@ export const getPresentationById = (presentationId) => async (dispatch) => {
   } catch (e) {
     console.log('getAccessToken error: ', e);
     dispatch(stopLoading());
-    return Promise.reject();    
+    return Promise.reject(e);    
   }
 
   const params = {
@@ -131,7 +131,7 @@ export const getPresentationById = (presentationId) => async (dispatch) => {
 
   return getRequest(
     null,
-    createAction(GET_PRESENTATION_DETAILS), // response needs no handling
+    createAction(GET_PRESENTATION_DETAILS),
     `${window.SUMMIT_API_BASE_URL}/api/v1/summits/${window.SUMMIT_ID}/presentations/voteable/${presentationId}`,
     customErrorHandler
   )(params)(dispatch).then((payload) => {
@@ -143,7 +143,7 @@ export const getPresentationById = (presentationId) => async (dispatch) => {
     dispatch(stopLoading());
     dispatch(createAction(GET_PRESENTATION_DETAILS_ERROR)(e));
     clearAccessToken();
-    return (e);
+    return Promise.reject(e);
   });
 };
 

--- a/src/templates/poster-detail-page.js
+++ b/src/templates/poster-detail-page.js
@@ -48,9 +48,12 @@ export const PosterDetailPage = ({
   uncastPresentationVote
 }) => {
 
-  const [poster, setPoster] = useState(null);
-  const [userCanViewPoster, setUserCanViewPoster] = useState(null);
-  const [posterTrackGroups, setPosterTrackGroups] = useState([]);
+  const [{ poster, posterTrackGroups, posterViewable }, setPosterState] = useState({
+    poster: null,
+    posterTrackGroups: [],
+    posterViewable: null
+  });
+
   const [notifiedVotingPeriodsOnLoad, setNotifiedVotingPeriodsOnLoad] = useState(false);
   const [notifiedMaximunAllowedVotesOnLoad, setNotifiedMaximunAllowedVotesOnLoad] = useState(false);
   const [previousVotingPeriods, setPreviousVotingPeriods] = useState(votingPeriods);
@@ -77,18 +80,17 @@ export const PosterDetailPage = ({
       let presentation;
       try {
         presentation = await getPresentationById(presentationId);
-        setPoster(presentation);
-      } catch (e) {}
+        setPosterState({
+          poster: presentation,
+          posterTrackGroups: presentation.track?.track_groups ?? [],
+          posterViewable: isAuthorizedBadge(presentation, user.userProfile.summit_tickets)
+        });
+      } catch (e) {
+        console.log(e);
+      }
     }
     fetchPresentation();
   }, [presentationId]);
-
-  useEffect(() => {
-    if (poster) {
-      setUserCanViewPoster(isAuthorized || isAuthorizedBadge(poster, user.userProfile.summit_tickets));
-      setPosterTrackGroups(poster.track?.track_groups ?? []);
-    }
-  }, [poster]);
 
   useEffect(() => {
     if (!notifiedVotingPeriodsOnLoad &&
@@ -144,11 +146,11 @@ export const PosterDetailPage = ({
     setPreviousVotingPeriods(votingPeriods);
   }, [posterTrackGroups, votingPeriods]);
 
-  if (loading || userCanViewPoster === null) return <HeroComponent title="Loading poster" />;
+  if (loading) return <HeroComponent title="Loading poster" />;
 
   if (!poster) return <HeroComponent title="Poster not found" />;
 
-  if (!userCanViewPoster) {
+  if (!posterViewable) {
     return <HeroComponent title={"Sorry. You need a special badge to view this poster."} redirectTo={location.state?.previousUrl || '/a/'} />;
   }
 

--- a/src/templates/poster-detail-page.js
+++ b/src/templates/poster-detail-page.js
@@ -49,7 +49,9 @@ export const PosterDetailPage = ({
 }) => {
 
   const [{ poster, posterTrackGroups, posterViewable }, setPosterState] = useState({
-    posterTrackGroups: []
+    poster: null,
+    posterTrackGroups: [],
+    posterViewable: false
   });
 
   const [notifiedVotingPeriodsOnLoad, setNotifiedVotingPeriodsOnLoad] = useState(false);
@@ -76,10 +78,10 @@ export const PosterDetailPage = ({
   useEffect(() => {
     getPresentationById(presentationId).then(presentation => {
       setPosterState({
-          poster: presentation,
-          posterTrackGroups: presentation.track?.track_groups ?? [],
-          posterViewable: isAuthorized || isAuthorizedBadge(presentation, user.userProfile.summit_tickets)
-        });
+        poster: presentation,
+        posterTrackGroups: presentation.track?.track_groups ?? [],
+        posterViewable: isAuthorized || isAuthorizedBadge(presentation, user.userProfile.summit_tickets)
+      });
     }).catch(e => console.log(e));
   }, [presentationId]);
 

--- a/src/templates/poster-detail-page.js
+++ b/src/templates/poster-detail-page.js
@@ -49,9 +49,7 @@ export const PosterDetailPage = ({
 }) => {
 
   const [{ poster, posterTrackGroups, posterViewable }, setPosterState] = useState({
-    poster: null,
-    posterTrackGroups: [],
-    posterViewable: null
+    posterTrackGroups: []
   });
 
   const [notifiedVotingPeriodsOnLoad, setNotifiedVotingPeriodsOnLoad] = useState(false);

--- a/src/templates/poster-detail-page.js
+++ b/src/templates/poster-detail-page.js
@@ -83,7 +83,7 @@ export const PosterDetailPage = ({
         setPosterState({
           poster: presentation,
           posterTrackGroups: presentation.track?.track_groups ?? [],
-          posterViewable: isAuthorizedBadge(presentation, user.userProfile.summit_tickets)
+          posterViewable: isAuthorized || isAuthorizedBadge(presentation, user.userProfile.summit_tickets)
         });
       } catch (e) {
         console.log(e);

--- a/src/templates/poster-detail-page.js
+++ b/src/templates/poster-detail-page.js
@@ -76,20 +76,13 @@ export const PosterDetailPage = ({
   }, []);
 
   useEffect(() => {
-    const fetchPresentation = async () => {
-      let presentation;
-      try {
-        presentation = await getPresentationById(presentationId);
-        setPosterState({
+    getPresentationById(presentationId).then(presentation => {
+      setPosterState({
           poster: presentation,
           posterTrackGroups: presentation.track?.track_groups ?? [],
           posterViewable: isAuthorized || isAuthorizedBadge(presentation, user.userProfile.summit_tickets)
         });
-      } catch (e) {
-        console.log(e);
-      }
-    }
-    fetchPresentation();
+    }).catch(e => console.log(e));
   }, [presentationId]);
 
   useEffect(() => {


### PR DESCRIPTION
Until now, when getPresentationById action erred out (either by a getAccessToken error or getRequest error), poster detail page got stuck rendering 'Loading poster'.
This PR fixes that.