### PR TITLE
Feature/a11y disqus component styles

### DIFF
--- a/src/components/DisqusComponent.js
+++ b/src/components/DisqusComponent.js
@@ -116,7 +116,6 @@ const DisqusComponent = class extends React.Component {
     const { title, style, className, disqusSSO, page, hideMobile = null, skipTo } = this.props;
     const { isMobile } = this.state || null;
     const sectionClass = className ? className : style ? '' : page === 'marketing-site' ? 'disqus-container-marketing' : 'disqus-container';
-    const paddingLeft = className !== 'disqus-container-home' ? '0px' : '15px';
 
     let disqusConfig = {
       url: window.location.href,
@@ -132,7 +131,7 @@ const DisqusComponent = class extends React.Component {
 
     return (
       <section aria-labelledby={title ? 'disqus-title' : ''} className={sectionClass} style={style}>
-        <div className="disqus-header" style={{ paddingLeft }}>
+        <div className="disqus-header">
           {skipTo && <a className="sr-only skip-to-next" href={skipTo}>Skip to next section</a>}
           {title && <h2 id="disqus-title" className="title">{title}</h2>}
         </div>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -403,11 +403,11 @@ h2 {
   flex-direction: column;
   max-height: 1500px;
 
-  span.navbar-brand {
+  .disqus-header {
     background-color: #fff;
-  }
-  > span {
     border-bottom: 1px solid #eee;
+    padding: 0 15px;
+    position: relative;
   }
   #disqus_thread {
     overflow: scroll;

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -432,7 +432,6 @@ h2 {
   }
   #disqus_thread {
     overflow: scroll;
-    margin-top: -10px;
     padding: 0 15px;
   }
 }

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -408,6 +408,27 @@ h2 {
     border-bottom: 1px solid #eee;
     padding: 0 15px;
     position: relative;
+    /*
+     Show Skip to next section link when focused
+     */
+    .skip-to-next:focus {
+      width: auto;
+      height: auto;
+      padding: 2px 5px;
+      margin: 0;
+      overflow: hidden;
+      clip: auto;
+      white-space: nowrap;
+      border: 0;
+      position: absolute;
+      left: 50%;
+      top: 20px;
+      transform: translateX(-50%);
+      background-color: white;
+      color: #363636;
+      z-index: 999;
+      text-decoration: none;
+    }
   }
   #disqus_thread {
     overflow: scroll;

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -431,7 +431,7 @@ h2 {
     }
   }
   #disqus_thread {
-    overflow: scroll;
+    overflow: auto;
     padding: 0 15px;
   }
 }


### PR DESCRIPTION
**What's broken**

The styles for changes added in #314 are missing.

**What kind of change does this PR introduce?**

Added styles for section header, skip to next section link and tweaked comments thread.

![imagen](https://user-images.githubusercontent.com/362365/157296110-9fd4bb1c-c19f-4495-ac20-a7a670679046.png)
