### PR TITLE
Feature/a11y clean html from cms

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "browser-tabs-lock": "^1.2.11",
     "bulma": "^0.9.0",
     "canvas": "^2.6.1",
+    "clean-html": "^1.5.0",
     "codemirror": "^5.55.0",
     "core-js": "^2.6.11",
     "cross-env": "^7.0.3",

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -1,9 +1,26 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
+import cleaner from 'clean-html'
 
-export const HTMLContent = ({ content, className }) => (
-  <div className={className} dangerouslySetInnerHTML={{ __html: content }} />
-)
+export const HTMLContent = ({ content, className }) => {
+  const [cleanHTML, setCleanHTML] = useState(content);
+  
+  useEffect(() => {
+    const options = {
+      'remove-empty-tags': ['a', 'p'],
+      'indent': '',
+      'break-around-tags': []
+    }
+    cleaner.clean(content, options, cleaned => {
+      console.log(cleaned)
+      setCleanHTML(cleaned)
+    })
+  }, [content])
+  
+  return (
+    <div className={className} dangerouslySetInnerHTML={{ __html: cleanHTML }} />
+  )
+}
 
 const Content = ({ content, className }) => (
   <div className={className}>{content}</div>

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -12,7 +12,6 @@ export const HTMLContent = ({ content, className }) => {
       'break-around-tags': []
     }
     cleaner.clean(content, options, cleaned => {
-      console.log(cleaned)
       setCleanHTML(cleaned)
     })
   }, [content])


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Content coming from CMS includes some malformed HTML, i. e. empty links wich causes duplicated tab stop on links.

![imagen](https://user-images.githubusercontent.com/362365/158661265-5408d346-7d11-4029-a48e-7be57c61fb46.png)

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Added a function from a module for cleaning the HTML in the Content component.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

Yes, `yarn install` should be run to install the package 'clean-html'.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

No documentation is needed.
