### PR TITLE
Remove middle diagonal

### DIFF
--- a/src/components/LobbyHeroComponent.js
+++ b/src/components/LobbyHeroComponent.js
@@ -18,7 +18,6 @@ const LobbyHeroComponent = ({homeSettings}) => (
           </div>
         </div>
       </div>
-      <div className={`${styles.midColumn} column is-1 is-info`} />
       <div className={`${styles.rightColumn} column is-danger`} style={{ backgroundImage: `url(${homeSettings.homeHero.image.file})` }} />
     </div>
   </section>

--- a/src/styles/lobby-hero.module.scss
+++ b/src/styles/lobby-hero.module.scss
@@ -12,7 +12,7 @@ div.column:first-of-type {
 
 .hero-columns {
   .left-column {
-    width: 70%;
+    width: 60%;
     background-color: $color_secondary_contrast;
     transform: skew(-25deg);
     margin-left: -10%;
@@ -50,7 +50,7 @@ div.column:first-of-type {
   }
 
   .right-column {
-    width: 65%;
+    width: 70%;
     z-index: 1;
     background-position: center;
     background-repeat: no-repeat;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Removes the middle bar on the lobby header

<img width="1786" alt="image" src="https://user-images.githubusercontent.com/19543853/160419350-fa791c1c-097f-43b0-b6dc-8e86a740675a.png">

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing


ref: https://tipit.avaza.com/project/view/305538#!tab=task-pane&task=2870743

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
