### PR TITLE
Adjusting header diagonal container

### DIFF
--- a/src/styles/lobby-hero.module.scss
+++ b/src/styles/lobby-hero.module.scss
@@ -12,16 +12,12 @@ div.column:first-of-type {
 
 .hero-columns {
   .left-column {
-    width: 60%;
+    width: 50%;
     background-color: $color_secondary_contrast;
-    transform: skew(-25deg);
-    margin-left: -10%;
     z-index: 3;
     min-height: 100%;
 
     .hero-container {
-      transform: skew(25deg);
-      margin-left: 15%;
     }
   }
 
@@ -50,12 +46,11 @@ div.column:first-of-type {
   }
 
   .right-column {
-    width: 70%;
+    width: 50%;
     z-index: 1;
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
-    margin-left: -10%;
     min-height: 100%;
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Changes the styles of the lobby header, removing the diagonal containers

<img width="1762" alt="image" src="https://user-images.githubusercontent.com/19543853/160884783-980e513f-14f4-417e-8eb6-2362c89c31b1.png">

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2870743

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>