### PR TITLE
Adding start time to video from event streaming url param

### DIFF
--- a/src/components/VideoComponent.js
+++ b/src/components/VideoComponent.js
@@ -25,7 +25,7 @@ const VideoComponent = class extends React.Component {
     }
 
     render() {
-        const {url, title, namespace, firstHalf, autoPlay} = this.props;
+        const {url, title, namespace, firstHalf, autoPlay, start} = this.props;
 
         if (url) {
             // vimeo player
@@ -34,6 +34,7 @@ const VideoComponent = class extends React.Component {
                     <VimeoPlayer
                         video={url}
                         autoplay={autoPlay}
+                        start={start}
                         className={styles.vimeoPlayer}
                     />
                 )
@@ -52,6 +53,7 @@ const VideoComponent = class extends React.Component {
                     controls: true,
                     fluid: true,
                     playsInline: true,
+                    start: start,
                     sources: [{
                         src: url,
                         type: 'application/x-mpegURL'

--- a/src/components/VideoJSPlayer.js
+++ b/src/components/VideoJSPlayer.js
@@ -9,7 +9,7 @@ import { getEnvVariable, MUX_ENV_KEY } from '../utils/envVariables'
 
 class VideoJSPlayer extends React.Component {
   componentDidMount() {
-    const { title, namespace, firstHalf } = this.props;
+    const { title, namespace, firstHalf, start } = this.props;
 
     let plugins = {}
 
@@ -40,6 +40,7 @@ class VideoJSPlayer extends React.Component {
 
     const onPlayerReady = () => {          
       const src = this.player.src();
+      if (start) this.player.currentTime(start);
       let reloadPlayer = null;
       let modal = null;
       let isLive = null;

--- a/src/templates/event-page.js
+++ b/src/templates/event-page.js
@@ -72,9 +72,11 @@ export const EventPageTemplate = class extends React.Component {
     const { event, user, loading, nowUtc, summit, eventsPhases, eventId, location } = this.props;
     // get current event phase
     const currentPhase = eventsPhases.find((e) => parseInt(e.id) === parseInt(eventId))?.phase;
-    const firstHalf = currentPhase === PHASES.DURING ? nowUtc < ((event?.start_date + event?.end_date) / 2) : false;
-    const eventQuery = URI(event.streaming_url).search(true);
-    const autoPlay = eventQuery.autoplay !== '0';
+    const firstHalf = currentPhase === PHASES.DURING ? nowUtc < ((event?.start_date + event?.end_date) / 2) : false;    
+    const eventQuery = event.streaming_url ? URI(event.streaming_url).search(true) : null;
+    const autoPlay = eventQuery?.autoplay !== '0';
+    // Start time set into seconds, first number is minutes so it multiply per 60
+    const startTime = eventQuery?.start?.split(',').reduce((a, b, index) => (index === 0 ? parseInt(b) * 60 : parseInt(b)) + a, 0);
 
     // if event is loading or we are still calculating the current phase ...
     if (loading || currentPhase === undefined) {
@@ -108,6 +110,7 @@ export const EventPageTemplate = class extends React.Component {
                       namespace={summit.name}
                       firstHalf={firstHalf}
                       autoPlay={autoPlay}
+                      start={startTime}
                     />
                     {event.meeting_url && <VideoBanner event={event} />}
                   </div>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Get the new start param from streaming_url and passed as prop to video component
* Fix for events without streaming_url

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/project/view/232086#!tab=task-pane&task=2888992

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
