### PR TITLE
Change options in clean-html to render images

### DIFF
--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -7,7 +7,7 @@ export const HTMLContent = ({ content, className }) => {
   
   useEffect(() => {
     const options = {
-      'remove-empty-tags': ['a', 'p'],
+      'remove-empty-tags': ['a'],
       'indent': '',
       'break-around-tags': []
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Changes the options to keep the `<p>` tags with images and no text

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/project/view/305538#!tab=task-pane&task=2891001

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
