### PR TITLE
Implements upcoming events widget link render props

### DIFF
--- a/src/templates/event-page.js
+++ b/src/templates/event-page.js
@@ -14,6 +14,7 @@ import SponsorComponent from "../components/SponsorComponent";
 import NoTalkComponent from "../components/NoTalkComponent";
 import HeroComponent from "../components/HeroComponent";
 import UpcomingEventsComponent from "../components/UpcomingEventsComponent";
+import Link from "../components/Link";
 import AccessTracker, { AttendeesWidget } from "../components/AttendeeToAttendeeWidgetComponent"
 import AttendanceTrackerComponent from "../components/AttendanceTrackerComponent";
 import { PHASES } from '../utils/phasesUtils';
@@ -42,10 +43,6 @@ export const EventPageTemplate = class extends React.Component {
     if (parseInt(eventId) !== parseInt(ev.id)) {
       navigate(`/a/event/${ev.id}`);
     }
-  }
-
-  onViewAllEventsClick() {
-    navigate("/a/schedule");
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -173,14 +170,18 @@ export const EventPageTemplate = class extends React.Component {
                       </div>
                     )}
                     <UpcomingEventsComponent
-                      onEventClick={(ev) => this.onEventChange(ev)}
-                      onViewAllEventsClick={() => this.onViewAllEventsClick()}
                       trackId={event.track ? event.track.id : null}
                       eventCount={3}
                       title={
                         event.track
                           ? `Up Next on ${event.track.name}`
                           : "Up Next"
+                      }
+                      renderEventLink={(event) => <Link to={`/a/event/${event.id}`}>{event.title}</Link>}
+                      allEventsLink={
+                        <Link to={event.track ? `/a/schedule#track=${event.track.id}` : "/a/schedule"}>
+                          View all <span className="sr-only">events</span>
+                        </Link>
                       }
                     />
                   </div>

--- a/src/templates/home-page.js
+++ b/src/templates/home-page.js
@@ -71,11 +71,11 @@ export const HomePageTemplate = class extends React.Component {
                 skipTo="#upcoming-events"
               />
               <UpcomingEventsComponent
-                renderEventLink={(event) => <Link to={`/a/event/${event.id}`}>{event.title}</Link>}
-                allEventsLink={<Link to="/a/schedule">View all <span className="sr-only">events</span></Link>}
                 title="Up Next"
                 eventCount={4}
-                />
+                renderEventLink={(event) => <Link to={`/a/event/${event.id}`}>{event.title}</Link>}
+                allEventsLink={<Link to="/a/schedule">View all <span className="sr-only">events</span></Link>}
+              />
               {homeSettings.centerColumn.speakers.showTodaySpeakers &&
                 <SpeakersWidgetComponent
                   title="Today's Speakers"

--- a/src/templates/sponsor-page.js
+++ b/src/templates/sponsor-page.js
@@ -62,10 +62,6 @@ export const SponsorPageTemplate = class extends React.Component {
     this.props.scanBadge(sponsorId);
   };
 
-  onViewAllEventsClick() {
-    navigate('/a/schedule')
-  }
-
   setSponsor = () => {
     const { sponsorId, sponsors, tiers } = this.props;
     const sponsor = sponsors.map(t => t.sponsors?.find(s => s.id === parseInt(sponsorId)))
@@ -136,10 +132,10 @@ export const SponsorPageTemplate = class extends React.Component {
                   }
                   {schedule &&
                   <UpcomingEventsComponent
-                      onEventClick={(ev) => this.onEventChange(ev)}
-                      onViewAllEventsClick={() => this.onViewAllEventsClick()}
                       eventCount={3}
                       sponsorId={sponsor.companyId}
+                      renderEventLink={(event) => <Link to={`/a/event/${event.id}`}>{event.title}</Link>}
+                      allEventsLink={<Link to={`/a/schedule#company=${encodeURIComponent(sponsor.name)}`}>View all <span className="sr-only">events</span></Link>}
                   />
                   }
                   {banner && <SponsorBanner sponsor={sponsor} bgColor={sponsor.sponsorColor} scanBadge={() => this.onBadgeScan()} />}


### PR DESCRIPTION
These PRs https://github.com/fntechgit/virtualevent-poc/pull/372, https://github.com/fntechgit/virtualevent-poc/pull/351 implemented upcoming events widget link render props _only_ on lobby template.

This PR implements those link render props on event detail and sponsor templates.

Also, as a bonus (or eastern egg), the View All link to schedule page now filters by track (if exists) on event detail template and by company on sponsor template.

Ref: https://tipit.avaza.com/project/view/232086#!tab=task-pane&groupby=ProjectSection&view=vertical&task=2892649&fileview=grid