### PR TITLE
Change copy text on sync calendar popup

### DIFF
--- a/src/templates/schedule-page.js
+++ b/src/templates/schedule-page.js
@@ -65,6 +65,8 @@ const SchedulePage = ({summit, scheduleState, summitPhase, isLoggedUser, locatio
     timezone,
     colorSource,
     schedKey,
+    modalSyncText: `Use the link below to add your saved sessions (found in My Schedule) to your personal 
+      calendar. Should you make changes later, use the Calendar Sync button to ensure these items are updated everywhere.`,
     ...scheduleProps
   };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Changes the copy text on the sync calendar popup

<img width="667" alt="image" src="https://user-images.githubusercontent.com/19543853/170590287-243beea9-e315-4a2b-a30b-0f697c45a2c7.png">


**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2883943

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>